### PR TITLE
Make radio button 'is-selected' more permissive wrt HTML structure

### DIFF
--- a/app/assets/javascripts/cfa_styleguide_main.js
+++ b/app/assets/javascripts/cfa_styleguide_main.js
@@ -69,9 +69,9 @@ var radioSelector = (function() {
           $(this).addClass('is-selected');
         }
 
-        $(this).find('input').click(function(e) {
-          $(this).parent().siblings().removeClass('is-selected');
-          $(this).parent().addClass('is-selected');
+        $(this).find('input').click(function (e) {
+          $(this).closest('.radio-button').siblings().removeClass('is-selected')
+          $(this).closest('.radio-button').addClass('is-selected')
         })
       })
     }

--- a/lib/cfa/styleguide/version.rb
+++ b/lib/cfa/styleguide/version.rb
@@ -1,5 +1,5 @@
 module Cfa
   module Styleguide
-    VERSION = "0.3.0"
+    VERSION = "0.3.1"
   end
 end


### PR DESCRIPTION
With accessibility improvements to the form builder (currently in Michigan + Colorado code bases, to be pulled into styleguide), we need a more permissive search for the relevant ancestor to assign 'is-selected' to for radio buttons. Right now, if a validation error is present then a selected radio button doesn't *appear* to be selected.

This change should work for both current cases: what's currently in GCF's form builder (parent), and what is in the newer version (grandparent).