### PR TITLE
Declare layout for Styleguide

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cfa-styleguide (0.3.0)
+    cfa-styleguide (0.4.1)
       autoprefixer-rails
       bourbon
       jquery-rails
@@ -157,7 +157,7 @@ GEM
     rspec-support (3.7.1)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
-    sass (3.5.7)
+    sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -193,4 +193,4 @@ DEPENDENCIES
   rspec_junit_formatter
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/app/controllers/cfa/styleguide/pages_controller.rb
+++ b/app/controllers/cfa/styleguide/pages_controller.rb
@@ -1,6 +1,8 @@
 module Cfa
   module Styleguide
     class PagesController < ApplicationController
+      layout "main"
+
       def index
       end
 

--- a/app/views/cfa/styleguide/pages/index.html.erb
+++ b/app/views/cfa/styleguide/pages/index.html.erb
@@ -406,8 +406,7 @@
       <div class="grid">
         <div class="grid__item">
           <div class="main-footer__legal">
-            <p>GetCalFresh.org is a service delivered by <a class="link--subtle" href="#">Code for America</a> on behalf of the people of California.</p>
-            <p>Read our <a class="link--subtle" href="#">Privacy Policy</a> and <a class="link--subtle" href="#">Nondiscrimination Statement.</a></p>
+            <p>The CfA Styleguide is a pattern library developed by <a class="link--subtle" href="#">Code for America</a>.</p>
           </div>
         </div>
       </div>

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>CfA Styleguide</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <%= csrf_meta_tags %>
+  <%= csp_meta_tag %>
+
+  <%= stylesheet_link_tag    'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
+</head>
+
+<body class="template--<%= content_for(:template_name) if content_for?(:template_name) %>">
+<div class="page-wrapper">
+  <%= content_for?(:content) ? content_for(:content) : yield %>
+</div>
+</body>
+</html>

--- a/lib/cfa/styleguide/version.rb
+++ b/lib/cfa/styleguide/version.rb
@@ -1,5 +1,5 @@
 module Cfa
   module Styleguide
-    VERSION = "0.3.1"
+    VERSION = "0.4.1"
   end
 end

--- a/spec/test_app/app/views/layouts/application.html.erb
+++ b/spec/test_app/app/views/layouts/application.html.erb
@@ -9,6 +9,9 @@
 
 <body>
 <%= yield %>
+<footer>
+  <%= root_path %>
+</footer>
 </body>
 
 </html>


### PR DESCRIPTION
Previously, the styleguide pages used whatever application they were
installed-in's application.html. This means if application-specific
routes (like root_path) were included in the layout, the styleguide
would break.

To fix this, we now have a generic application.html layout that all CfA
styleguide pages use by default.

Fixes https://github.com/codeforamerica/cfa-styleguide-gem/issues/9