### PR TITLE
Fix styling on non-main styleguide pages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cfa-styleguide (0.4.1)
+    cfa-styleguide (0.4.2)
       autoprefixer-rails
       bourbon
       jquery-rails

--- a/app/views/cfa/styleguide/pages/cbo_analytics.html.erb
+++ b/app/views/cfa/styleguide/pages/cbo_analytics.html.erb
@@ -1,100 +1,70 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <%= display_meta_tags %>
+<% content_for(:template_name) { "dashboard" } %>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    <%= stylesheet_link_tag 'main', media: 'all' %>
-    <%= javascript_include_tag 'application', async: true  %>
-
-    <%= csrf_meta_tags %>
-  </head>
-  <body class="template--dashboard">
-    <div class="page-wrapper">
-      <header class="main-header">
-        <div class="toolbar">
-          <div class="toolbar__left">
-            <h1 class="main-header__title"><a class="main-header__logo" href="#"><b>GetCalFresh.org</b> | SF Marin Food Bank</a></h1>
-          </div>
-          <div class="toolbar__right">
-            <a href="#" class="toolbar__item text--help">Assister dashboard</a>
-            <a href="#" class="toolbar__item text--help">Log out</a>
-          </div>
-        </div>
-      </header>
-      <div class="tab-bar">
-        <a href="#" class="tab-bar__tab">Clients</a>
-        <a href="#" class="tab-bar__tab is-selected">Analytics</a>
-        <a href="#" class="tab-bar__tab">Team</a>
-      </div>
-      <div class="dashboard-main">
-        <div class="slab with-padding-med">
-          <h2 class="with-padding-med">Overall numbers</h2>
-          <div class="grid">
-            <div class="grid__item width-one-third">
-              <div class="statistic-card">
-                <p class="statistic-card__label">Applications submitted</p>
-                <p class="statistic-card__number">47 apps</p>
-              </div>
-              <div class="statistic-card">
-                <p class="statistic-card__label">Average completion time</p>
-                <p class="statistic-card__number">10 mins</p>
-              </div>
-            </div>
-            <div class="grid__item width-two-thirds">
-              <div class="statistic-card" style="height: 18.3em;">
-                <p class="statistic-card__label">By the day</p>
-                <p class="statistic-card__number"></p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="slab with-padding-med">
-          <h2 class="with-padding-med">Client demographics</h2>
-          <div class="grid">
-            <div class="grid__item width-one-fourth">
-              <div class="statistic-card">
-                <p class="statistic-card__label">Total people helped</p>
-                <p class="statistic-card__number">47 👤</p>
-              </div>
-            </div>
-            <div class="grid__item width-one-fourth">
-              <div class="statistic-card">
-                <p class="statistic-card__label">Students</p>
-                <p class="statistic-card__number">8  🎓</p>
-              </div>
-            </div>
-            <div class="grid__item width-one-fourth">
-              <div class="statistic-card">
-                <p class="statistic-card__label">Children</p>
-                <p class="statistic-card__number">12 👶</p>
-              </div>
-            </div>
-            <div class="grid__item width-one-fourth">
-              <div class="statistic-card">
-                <p class="statistic-card__label">Seniors</p>
-                <p class="statistic-card__number">5 👵</p>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <footer class="main-footer">
-        <div class="grid">
-          <div class="grid__item width-three-fourths">
-            <div class="main-footer__legal">
-              <p>GetCalFresh.org is a service delivered by <a class="link--subtle" href="https://www.codeforamerica.org">Code for America</a> on behalf of the people of California.</p>
-              <p>Read our <a class="link--subtle" href="/privacy">Privacy Policy</a> and <a class="link--subtle" href="/nondiscrimination">Nondiscrimination Statement.</a> Learn more <a class="link--subtle" href="/about">about this site</a>.</p>
-            </div>
-          </div>
-          <div class="grid__item width-one-sixth shift-one-twelfth">
-            <div class="main-footer__cfa-logo">
-              <a href="https://www.codeforamerica.org"><img src="<%= image_path('cfa_logo.png') %>" alt="Code for America"></a>
-            </div>
-          </div>
-        </div>
-      </footer>
+<header class="main-header">
+  <div class="toolbar">
+    <div class="toolbar__left">
+      <h1 class="main-header__title"><a class="main-header__logo" href="#"><b>GetCalFresh.org</b> | SF Marin Food Bank</a></h1>
     </div>
-  </body>
-</html>
+    <div class="toolbar__right">
+      <a href="#" class="toolbar__item text--help">Assister dashboard</a>
+      <a href="#" class="toolbar__item text--help">Log out</a>
+    </div>
+  </div>
+</header>
+<div class="tab-bar">
+  <a href="#" class="tab-bar__tab">Clients</a>
+  <a href="#" class="tab-bar__tab is-selected">Analytics</a>
+  <a href="#" class="tab-bar__tab">Team</a>
+</div>
+<div class="dashboard-main">
+  <div class="slab with-padding-med">
+    <h2 class="with-padding-med">Overall numbers</h2>
+    <div class="grid">
+      <div class="grid__item width-one-third">
+        <div class="statistic-card">
+          <p class="statistic-card__label">Applications submitted</p>
+          <p class="statistic-card__number">47 apps</p>
+        </div>
+        <div class="statistic-card">
+          <p class="statistic-card__label">Average completion time</p>
+          <p class="statistic-card__number">10 mins</p>
+        </div>
+      </div>
+      <div class="grid__item width-two-thirds">
+        <div class="statistic-card" style="height: 18.3em;">
+          <p class="statistic-card__label">By the day</p>
+          <p class="statistic-card__number"></p>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="slab with-padding-med">
+    <h2 class="with-padding-med">Client demographics</h2>
+    <div class="grid">
+      <div class="grid__item width-one-fourth">
+        <div class="statistic-card">
+          <p class="statistic-card__label">Total people helped</p>
+          <p class="statistic-card__number">47 👤</p>
+        </div>
+      </div>
+      <div class="grid__item width-one-fourth">
+        <div class="statistic-card">
+          <p class="statistic-card__label">Students</p>
+          <p class="statistic-card__number">8  🎓</p>
+        </div>
+      </div>
+      <div class="grid__item width-one-fourth">
+        <div class="statistic-card">
+          <p class="statistic-card__label">Children</p>
+          <p class="statistic-card__number">12 👶</p>
+        </div>
+      </div>
+      <div class="grid__item width-one-fourth">
+        <div class="statistic-card">
+          <p class="statistic-card__label">Seniors</p>
+          <p class="statistic-card__number">5 👵</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/cfa/styleguide/pages/cbo_dashboard.html.erb
+++ b/app/views/cfa/styleguide/pages/cbo_dashboard.html.erb
@@ -1,176 +1,146 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <%= display_meta_tags %>
+<% content_for(:template_name) { "dashboard" } %>
 
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-
-    <%= stylesheet_link_tag 'main', media: 'all' %>
-    <%= javascript_include_tag 'application', async: true  %>
-
-    <%= csrf_meta_tags %>
-  </head>
-  <body class="template--dashboard">
-    <div class="page-wrapper">
-      <header class="main-header">
-        <div class="toolbar">
-          <div class="toolbar__left">
-            <h1 class="main-header__title"><a class="main-header__logo" href="#"><b>GetCalFresh.org</b> | SF Marin Food Bank</a></h1>
-          </div>
-          <div class="toolbar__right">
-            <a href="#" class="toolbar__item text--help">Assister dashboard</a>
-            <a href="#" class="toolbar__item text--help">Log out</a>
-          </div>
-        </div>
-      </header>
-      <div class="tab-bar">
-        <a href="#" class="tab-bar__tab is-selected">Clients</a>
-        <a href="#" class="tab-bar__tab">Analytics</a>
-        <a href="#" class="tab-bar__tab">Team</a>
-      </div>
-      <div class="dashboard-toolbar toolbar">
-        <div class="toolbar__left">
-          <form class="searchbar form-width--searchbar toolbar__item">
-            <input type="text" class="searchbar__input" placeholder="Search applicants by name or confirmation #">
-            <label class="searchbar__button"><span class="icon icon-arrow_forward"></span><button type="submit"></button></label>
-          </form>
-        </div>
-        <div class="toolbar__right">
-          <a href="#" class="button toolbar__item">Submit documents</a>
-          <a href="#" class="button button--cta toolbar__item"><span class="icon icon-add"></span> New application</a>
-        </div>
-      </div>
-      <div class="dashboard-main">
-        <div class="grid">
-          <div class="grid__item width-one-whole">
-            <div class="data-table-container">
-              <table class="data-table data-table--selectable">
-                <thead>
-                  <tr>
-                   <th><a href="#">Name <span class="icon icon-arrow_drop_down"></span></a></th>
-                   <th>Birth date</th>
-                   <th>Email</th>
-                   <th>Phone</th>
-                   <th><a href="#" class="is-selected">Submit date <span class="icon icon-arrow_drop_down"></span></a></th>
-                   <th>Confirmation #</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Applicant 1</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                  <tr>
-                    <td>Applicant 2</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                  <tr>
-                    <td>Applicant 3</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                  <tr>
-                    <td>Applicant 4</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                  <tr>
-                    <td>Applicant 5</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                  <tr>
-                    <td>Applicant 6</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                  <tr>
-                    <td>Applicant 7</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                  <tr>
-                    <td>Applicant 8</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                  <tr>
-                    <td>Applicant 9</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                  <tr>
-                    <td>Applicant 10</td>
-                    <td>04/02/1988</td>
-                    <td><span class="icon icon-markunread"></span></td>
-                    <td>555-555-5555</td>
-                    <td>10/16/2016</td>
-                    <td>AKJHSD83K</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <div class="pagination">
-              <div class="pagination__info">
-                <p class="text--help">Displaying 1-20 of 344 applicants</p>
-              </div>
-              <div class="pagination__buttons">
-                <button class="button button--small"><i class="icon icon-keyboard_arrow_left"></i></button>
-                <button class="button button--small pagination__selected">1</button>
-                <button class="button button--small">2</button>
-                <button class="button button--small">3</button>
-                <span class="pagination__ellipsis">&hellip;</span>
-                <button class="button button--small">6</button>
-                <button class="button button--small"><i class="icon icon-keyboard_arrow_right"></i></button>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <footer class="main-footer">
-        <div class="grid">
-          <div class="grid__item width-three-fourths">
-            <div class="main-footer__legal">
-              <p>GetCalFresh.org is a service delivered by <a class="link--subtle" href="https://www.codeforamerica.org">Code for America</a> on behalf of the people of California.</p>
-              <p>Read our <a class="link--subtle" href="/privacy">Privacy Policy</a> and <a class="link--subtle" href="/nondiscrimination">Nondiscrimination Statement.</a> Learn more <a class="link--subtle" href="/about">about this site</a>.</p>
-            </div>
-          </div>
-          <div class="grid__item width-one-sixth shift-one-twelfth">
-            <div class="main-footer__cfa-logo">
-              <a href="https://www.codeforamerica.org"><img src="<%= image_path('cfa_logo.png') %>" alt="Code for America"></a>
-            </div>
-          </div>
-        </div>
-      </footer>
+<header class="main-header">
+  <div class="toolbar">
+    <div class="toolbar__left">
+      <h1 class="main-header__title"><a class="main-header__logo" href="#"><b>GetCalFresh.org</b> | SF Marin Food Bank</a></h1>
     </div>
-  </body>
-</html>
+    <div class="toolbar__right">
+      <a href="#" class="toolbar__item text--help">Assister dashboard</a>
+      <a href="#" class="toolbar__item text--help">Log out</a>
+    </div>
+  </div>
+</header>
+<div class="tab-bar">
+  <a href="#" class="tab-bar__tab is-selected">Clients</a>
+  <a href="#" class="tab-bar__tab">Analytics</a>
+  <a href="#" class="tab-bar__tab">Team</a>
+</div>
+<div class="dashboard-toolbar toolbar">
+  <div class="toolbar__left">
+    <form class="searchbar form-width--searchbar toolbar__item">
+      <input type="text" class="searchbar__input" placeholder="Search applicants by name or confirmation #">
+      <label class="searchbar__button"><span class="icon icon-arrow_forward"></span><button type="submit"></button></label>
+    </form>
+  </div>
+  <div class="toolbar__right">
+    <a href="#" class="button toolbar__item">Submit documents</a>
+    <a href="#" class="button button--cta toolbar__item"><span class="icon icon-add"></span> New application</a>
+  </div>
+</div>
+<div class="dashboard-main">
+  <div class="grid">
+    <div class="grid__item width-one-whole">
+      <div class="data-table-container">
+        <table class="data-table data-table--selectable">
+          <thead>
+            <tr>
+             <th><a href="#">Name <span class="icon icon-arrow_drop_down"></span></a></th>
+             <th>Birth date</th>
+             <th>Email</th>
+             <th>Phone</th>
+             <th><a href="#" class="is-selected">Submit date <span class="icon icon-arrow_drop_down"></span></a></th>
+             <th>Confirmation #</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Applicant 1</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+            <tr>
+              <td>Applicant 2</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+            <tr>
+              <td>Applicant 3</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+            <tr>
+              <td>Applicant 4</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+            <tr>
+              <td>Applicant 5</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+            <tr>
+              <td>Applicant 6</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+            <tr>
+              <td>Applicant 7</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+            <tr>
+              <td>Applicant 8</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+            <tr>
+              <td>Applicant 9</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+            <tr>
+              <td>Applicant 10</td>
+              <td>04/02/1988</td>
+              <td><span class="icon icon-markunread"></span></td>
+              <td>555-555-5555</td>
+              <td>10/16/2016</td>
+              <td>AKJHSD83K</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="pagination">
+        <div class="pagination__info">
+          <p class="text--help">Displaying 1-20 of 344 applicants</p>
+        </div>
+        <div class="pagination__buttons">
+          <button class="button button--small"><i class="icon icon-keyboard_arrow_left"></i></button>
+          <button class="button button--small pagination__selected">1</button>
+          <button class="button button--small">2</button>
+          <button class="button button--small">3</button>
+          <span class="pagination__ellipsis">&hellip;</span>
+          <button class="button button--small">6</button>
+          <button class="button button--small"><i class="icon icon-keyboard_arrow_right"></i></button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/cfa/styleguide/pages/current.html.erb
+++ b/app/views/cfa/styleguide/pages/current.html.erb
@@ -1,91 +1,76 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <%= display_meta_tags %>
+<% content_for(:template_name) { "question" } %>
 
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<header class="main-header">
+  <div class="toolbar">
+    <div class="toolbar__left">
+      <h1 class="main-header__title"><a href="#" class="main-header__logo"><b>GetCalFresh.org</b></a></h1>
+    </div>
+    <div class="toolbar__right">
+      <a href="#" class="toolbar__item text--small">Español</a>
+    </div>
+  </div>
+</header>
+<div class="slab">
+  <div class="grid">
+    <div class="grid__item width-five-sixths shift-one-twelfth">
 
-  <%= stylesheet_link_tag 'main', media: 'all' %>
-  <%= javascript_include_tag 'application'  %>
-
-  <%= csrf_meta_tags %>
-</head>
-<body class="template--question">
-  <div class="page-wrapper">
-    <header class="main-header">
-      <div class="toolbar">
-        <div class="toolbar__left">
-          <h1 class="main-header__title"><a href="#" class="main-header__logo"><b>GetCalFresh.org</b></a></h1>
+      <div class="form-card with-padding-large">
+        <div class="form-card__header form-card__header--with-icon">
+          <div class="form-card__icon emoji emoji--med emoji--page-facing-up"></div>
+          <h1 class="form-card__title">The legal stuff.</h1>
+          <p class="text--small">Scroll down to agree</p>
         </div>
-        <div class="toolbar__right">
-          <a href="#" class="toolbar__item text--small">Español</a>
+        <div class="form-card__content">
+          <h3>Summary</h3>
+          <ul class="list--bulleted">
+            <li>I have been honest on this report.</li>
+            <li>I have attached all required documents.</li>
+            <li>I understand the county may contact whomever to verify my eligibility.</li>
+            <li>I have read the <a href="#">CalFresh Program Rules and Penalties</a>.</li>
+          </ul>
+          <h3>Details</h3>
+          <ul class="list--bulleted">
+            <li>I understand and certify, under penalty of perjury, that all my answers on this report are correct and complete to the best of my knowledge.</li>
+            <li>I understand the penalties for fraud are as follows: I may be sent to prison for up to 20 years and fined up to $250,000. I may have to pay back benefits if I was not eligible to them. The first time I break the rules on purpose I will not be able to get CalFresh for one year; the second time two years; and after the third time I will not be able to get CalFresh again.</li>
+            <li>I understand and agree to give copies of all documents needed to complete my semi-annual report.</li>
+            <li>I understand that in some instances, I may be asked to give consent to the County to make whatever contacts are necessary todetermine eligibility.</li>
+            <li>I understand that if on purpose I do not report all facts or give wrong facts about my income, property, or family status to get or keep getting aid or benefits, I can be legally prosecuted. I may also be charged with committing a felony if more than $950 in Cash Aid, and/or CalFresh is wrongly paid out as a result of such an action. I have received a copy of the Instructions and Penalties for the SAR 7 Eligibility Status Report for Cash Aid and CalFresh.</li>
+          </ul>
+        </div>
+        <fieldset class="form-group input-group--inline">
+          <label class="checkbox">
+            <input type="checkbox"> Click to agree
+          </label>
+        </fieldset>
+        <div class="form-card__footer">
+          <a href="#" class="button button--primary">Continue</a>
         </div>
       </div>
-    </header>
-    <div class="slab">
-      <div class="grid">
-        <div class="grid__item width-five-sixths shift-one-twelfth">
 
-          <div class="form-card with-padding-large">
-            <div class="form-card__header form-card__header--with-icon">
-              <div class="form-card__icon emoji emoji--med emoji--page-facing-up"></div>
-              <h1 class="form-card__title">The legal stuff.</h1>
-              <p class="text--small">Scroll down to agree</p>
-            </div>
-            <div class="form-card__content">
-              <h3>Summary</h3>
-              <ul class="list--bulleted">
-                <li>I have been honest on this report.</li>
-                <li>I have attached all required documents.</li>
-                <li>I understand the county may contact whomever to verify my eligibility.</li>
-                <li>I have read the <a href="#">CalFresh Program Rules and Penalties</a>.</li>
-              </ul>
-              <h3>Details</h3>
-              <ul class="list--bulleted">
-                <li>I understand and certify, under penalty of perjury, that all my answers on this report are correct and complete to the best of my knowledge.</li>
-                <li>I understand the penalties for fraud are as follows: I may be sent to prison for up to 20 years and fined up to $250,000. I may have to pay back benefits if I was not eligible to them. The first time I break the rules on purpose I will not be able to get CalFresh for one year; the second time two years; and after the third time I will not be able to get CalFresh again.</li>
-                <li>I understand and agree to give copies of all documents needed to complete my semi-annual report.</li>
-                <li>I understand that in some instances, I may be asked to give consent to the County to make whatever contacts are necessary todetermine eligibility.</li>
-                <li>I understand that if on purpose I do not report all facts or give wrong facts about my income, property, or family status to get or keep getting aid or benefits, I can be legally prosecuted. I may also be charged with committing a felony if more than $950 in Cash Aid, and/or CalFresh is wrongly paid out as a result of such an action. I have received a copy of the Instructions and Penalties for the SAR 7 Eligibility Status Report for Cash Aid and CalFresh.</li>
-              </ul>
-            </div>
-            <fieldset class="form-group input-group--inline">
-              <label class="checkbox">
-                <input type="checkbox"> Click to agree
-              </label>
-            </fieldset>
-            <div class="form-card__footer">
-              <a href="#" class="button button--primary">Continue</a>
-            </div>
+      <div class="card form-card form-card--transition">
+        <div class="form-card__content">
+          <div class="emoji emoji--big emoji--money"></div>
+          <h3 class="with-padding-small">How much money do you get every month <b>not from jobs</b>?</h3>
+          <p class="text--small">Examples:</p>
+          <div class="text--centered">
+            <p>
+              <span class="example">Social Security</span>
+              <span class="example">Disability</span>
+              <span class="example">Unemployment</span>
+              <span class="example">Military BAH</span>
+              <span class="example">Child support</span>
+              <span class="example">Alimony</span>
+              <span class="example">Worker's Comp</span>
+              <span class="example">Money from friend or relative</span>
+            </p>
           </div>
+          <p>
+            <a href="#" class="button"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span> Yes</a>
+            <a href="#" class="button"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span> No</a>
+          </p>
+        </div>
+      </div>
 
-          <div class="card form-card form-card--transition">
-            <div class="form-card__content">
-              <div class="emoji emoji--big emoji--money"></div>
-              <h3 class="with-padding-small">How much money do you get every month <b>not from jobs</b>?</h3>
-              <p class="text--small">Examples:</p>
-              <div class="text--centered">
-                <p>
-                  <span class="example">Social Security</span>
-                  <span class="example">Disability</span>
-                  <span class="example">Unemployment</span>
-                  <span class="example">Military BAH</span>
-                  <span class="example">Child support</span>
-                  <span class="example">Alimony</span>
-                  <span class="example">Worker's Comp</span>
-                  <span class="example">Money from friend or relative</span>
-                </p>
-              </div>
-              <p>
-                <a href="#" class="button"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span> Yes</a>
-                <a href="#" class="button"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span> No</a>
-              </p>
-            </div>
-          </div>
-
-          </div> <!-- .grid item -->
-        </div> <!-- .grid -->
-      </div> <!-- .slab -->
-    </div> <!-- .page-wrapper -->
-  </body>
-</html>
+    </div> <!-- .grid item -->
+  </div> <!-- .grid -->
+</div> <!-- .slab -->

--- a/app/views/cfa/styleguide/pages/custom_docs.html.erb
+++ b/app/views/cfa/styleguide/pages/custom_docs.html.erb
@@ -1,278 +1,264 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <%= display_meta_tags %>
+<% content_for(:template_name) { "question" } %>
 
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<header class="main-header">
+  <div class="toolbar">
+    <div class="toolbar__left">
+      <h1 class="main-header__title"><a href="#" class="main-header__logo"><b>GetCalFresh.org</b></a></h1>
+    </div>
+    <div class="toolbar__right">
+      <a href="#" class="toolbar__item text--small">Español</a>
+    </div>
+  </div>
+</header>
+<div class="slab">
+  <div class="grid">
+    <div class="grid__item width-five-sixths shift-one-twelfth">
 
-  <%= stylesheet_link_tag 'main', media: 'all' %>
-  <%= javascript_include_tag 'application'  %>
-  <%= csrf_meta_tags %>
-</head>
-<body class="template--question">
-  <div class="page-wrapper">
-    <header class="main-header">
-      <div class="toolbar">
-        <div class="toolbar__left">
-          <h1 class="main-header__title"><a href="#" class="main-header__logo"><b>GetCalFresh.org</b></a></h1>
+      <div class="form-card form-card--transition">
+        <div class="form-card__header">
+          <div class="emoji emoji--big emoji--star with-padding-med"></div>
+          <h1 class="form-card__title with-padding-med">First, we’ll need to figure out what proof you need to submit.</h1>
         </div>
-        <div class="toolbar__right">
-          <a href="#" class="toolbar__item text--small">Español</a>
+        <div class="form-card__content">
+          <a href="#" class="button button--primary">Continue</a>
         </div>
       </div>
-    </header>
-    <div class="slab">
-      <div class="grid">
-        <div class="grid__item width-five-sixths shift-one-twelfth">
 
-          <div class="form-card form-card--transition">
-            <div class="form-card__header">
-              <div class="emoji emoji--big emoji--star with-padding-med"></div>
-              <h1 class="form-card__title with-padding-med">First, we’ll need to figure out what proof you need to submit.</h1>
-            </div>
-            <div class="form-card__content">
-              <a href="#" class="button button--primary">Continue</a>
+      <br><br>
+
+      <div class="form-card form-card--transition">
+        <div class="form-card__header">
+          <div class="emoji emoji--big emoji--farmer-female with-padding-small"></div>
+          <div class="emoji emoji--big emoji--construction-worker with-padding-small"></div>
+        </div>
+        <div class="form-card__content">
+          <h3 class="with-padding-large">Does anyone in the household <b>have a job</b>?</h3>
+          <div class="toolbar toolbar--centered">
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
+          </div>
+          <ul class="progress-dots">
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+          </ul>
+        </div>
+      </div>
+
+      <br><br>
+
+      <div class="form-card form-card--transition">
+        <div class="form-card__header">
+          <div class="emoji emoji--big emoji--money with-padding-small"></div>
+        </div>
+        <div class="form-card__content">
+          <h3 class="with-padding-large">Does anyone in the household get <b>money not from a job</b>?</h3>
+          <div class="toolbar toolbar--centered">
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
+          </div>
+          <ul class="progress-dots">
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+          </ul>
+        </div>
+      </div>
+
+      <br><br>
+
+      <div class="form-card form-card--transition">
+        <div class="form-card__header">
+          <div class="emoji emoji--big emoji--briefcase with-padding-small"></div>
+        </div>
+        <div class="form-card__content">
+          <h3 class="with-padding-large">Has anyone <b>lost their job</b> in the last 30 days??</h3>
+          <div class="toolbar toolbar--centered">
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
+          </div>
+          <ul class="progress-dots">
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+          </ul>
+        </div>
+      </div>
+
+      <br><br>
+
+      <div class="form-card form-card--transition">
+        <div class="form-card__header">
+          <div class="emoji emoji--big emoji--earth with-padding-small"></div>
+        </div>
+        <div class="form-card__content">
+          <h3 class="with-padding-large">Is everyone in the household is a <b>US Citizen</b>?</h3>
+          <div class="toolbar toolbar--centered">
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
+          </div>
+          <ul class="progress-dots">
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+          </ul>
+        </div>
+      </div>
+
+      <br><br>
+
+      <div class="form-card form-card--transition">
+        <div class="form-card__header">
+          <div class="emoji emoji--big emoji--baby with-padding-small"></div>
+        </div>
+        <div class="form-card__content">
+          <h3 class="with-padding-large">Does anyone in the household <b>pay for child support</b>?</h3>
+          <div class="toolbar toolbar--centered">
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
+          </div>
+          <ul class="progress-dots">
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot"></li>
+            <li class="progress-dots__dot"></li>
+          </ul>
+        </div>
+      </div>
+
+      <br><br>
+
+      <div class="form-card form-card--transition">
+        <div class="form-card__header">
+          <div class="emoji emoji--big emoji--older-woman with-padding-small"></div>
+          <div class="emoji emoji--big emoji--older-man with-padding-small"></div>
+          <div class="emoji emoji--big emoji--disabled with-padding-small"></div>
+        </div>
+        <div class="form-card__content">
+          <h3 class="with-padding-large">Is anyone in the household <b>60 or older</b> or <b>disabled</b>?</h3>
+          <div class="toolbar toolbar--centered">
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
+          </div>
+          <ul class="progress-dots">
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot"></li>
+          </ul>
+        </div>
+      </div>
+
+      <br><br>
+
+      <div class="form-card form-card--transition">
+        <div class="form-card__header">
+          <div class="emoji emoji--big emoji--pill with-padding-small"></div>
+        </div>
+        <div class="form-card__content">
+          <h3>Does this person have any <b>medical expenses</b>?</h3>
+          <p class="with-padding-large">E.g., medical, dental, nursing care, hospitalization, medicine, health equipment, and medical transportation.</p>
+          <div class="toolbar toolbar--centered">
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
+            <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
+          </div>
+          <ul class="progress-dots">
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+            <li class="progress-dots__dot is-completed"></li>
+          </ul>
+        </div>
+      </div>
+
+      <br><br>
+
+      <div class="form-card form-card--transition">
+        <div class="form-card__header">
+          <div class="emoji emoji--big emoji--star with-padding-med"></div>
+          <h1 class="form-card__title with-padding-med">Great, now let’s help you submit the right proof.</h1>
+        </div>
+        <div class="form-card__content">
+          <a href="#" class="button button--primary">Continue</a>
+        </div>
+      </div>
+
+      <br><br>
+
+      <div class="form-card form-card--transition">
+        <div class="form-card__content">
+          <div class="form-card__header">
+            <div class="emoji emoji--big emoji--bust with-padding-small"></div>
+            <p class="text--caps">Proof of identity</p>
+            <h3>Can you submit any of the following for Laura and Chris?</h3>
+            <ul class="with-padding-med">
+              <li class="example">Driver's license or ID</li>
+              <li class="example">Passport</li>
+              <li class="example">Student, jail, or other photo ID</li>
+            </ul>
+            <div class="select">
+              <select class="select__element" name="example_select" id="example_select">
+                <option selected disabled>Choose a selection</option>
+                <option value="1">I can submit now</option>
+                <option value="2">I need more time</option>
+                <option value="2">I need more help</option>
+              </select>
             </div>
           </div>
+          <a href="#" class="button button--primary">Continue</a>
+        </div>
+      </div>
 
-          <br><br>
+      <br><br>
 
-          <div class="form-card form-card--transition">
-            <div class="form-card__header">
-              <div class="emoji emoji--big emoji--farmer-female with-padding-small"></div>
-              <div class="emoji emoji--big emoji--construction-worker with-padding-small"></div>
-            </div>
-            <div class="form-card__content">
-              <h3 class="with-padding-large">Does anyone in the household <b>have a job</b>?</h3>
-              <div class="toolbar toolbar--centered">
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
-              </div>
-              <ul class="progress-dots">
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-              </ul>
-            </div>
-          </div>
-
-          <br><br>
-
-          <div class="form-card form-card--transition">
-            <div class="form-card__header">
-              <div class="emoji emoji--big emoji--money with-padding-small"></div>
-            </div>
-            <div class="form-card__content">
-              <h3 class="with-padding-large">Does anyone in the household get <b>money not from a job</b>?</h3>
-              <div class="toolbar toolbar--centered">
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
-              </div>
-              <ul class="progress-dots">
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-              </ul>
+      <div class="form-card form-card--transition">
+        <div class="form-card__content">
+          <div class="form-card__header">
+            <div class="emoji emoji--big emoji--farmer-female with-padding-small"></div>
+            <div class="emoji emoji--big emoji--construction-worker with-padding-small"></div>
+            <p class="text--caps">Proof for jobs</p>
+            <h3>Can you submit any of the following?</h3>
+            <ul class="with-padding-med">
+              <li class="example">Pay stubs from last 30 days</li>
+              <li class="example">Letter from employer with gross pay, hours worked, etc.</li>
+            </ul>
+            <div class="select">
+              <select class="select__element" name="example_select" id="example_select">
+                <option selected disabled>Choose a selection</option>
+                <option value="1">I can submit now</option>
+                <option value="2">I need more time</option>
+                <option value="2">I need more help</option>
+              </select>
             </div>
           </div>
-
-          <br><br>
-
-          <div class="form-card form-card--transition">
-            <div class="form-card__header">
-              <div class="emoji emoji--big emoji--briefcase with-padding-small"></div>
-            </div>
-            <div class="form-card__content">
-              <h3 class="with-padding-large">Has anyone <b>lost their job</b> in the last 30 days??</h3>
-              <div class="toolbar toolbar--centered">
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
-              </div>
-              <ul class="progress-dots">
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-              </ul>
-            </div>
-          </div>
-
-          <br><br>
-
-          <div class="form-card form-card--transition">
-            <div class="form-card__header">
-              <div class="emoji emoji--big emoji--earth with-padding-small"></div>
-            </div>
-            <div class="form-card__content">
-              <h3 class="with-padding-large">Is everyone in the household is a <b>US Citizen</b>?</h3>
-              <div class="toolbar toolbar--centered">
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
-              </div>
-              <ul class="progress-dots">
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-              </ul>
-            </div>
-          </div>
-
-          <br><br>
-
-          <div class="form-card form-card--transition">
-            <div class="form-card__header">
-              <div class="emoji emoji--big emoji--baby with-padding-small"></div>
-            </div>
-            <div class="form-card__content">
-              <h3 class="with-padding-large">Does anyone in the household <b>pay for child support</b>?</h3>
-              <div class="toolbar toolbar--centered">
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
-              </div>
-              <ul class="progress-dots">
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot"></li>
-                <li class="progress-dots__dot"></li>
-              </ul>
-            </div>
-          </div>
-
-          <br><br>
-
-          <div class="form-card form-card--transition">
-            <div class="form-card__header">
-              <div class="emoji emoji--big emoji--older-woman with-padding-small"></div>
-              <div class="emoji emoji--big emoji--older-man with-padding-small"></div>
-              <div class="emoji emoji--big emoji--disabled with-padding-small"></div>
-            </div>
-            <div class="form-card__content">
-              <h3 class="with-padding-large">Is anyone in the household <b>60 or older</b> or <b>disabled</b>?</h3>
-              <div class="toolbar toolbar--centered">
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
-              </div>
-              <ul class="progress-dots">
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot"></li>
-              </ul>
-            </div>
-          </div>
-
-          <br><br>
-
-          <div class="form-card form-card--transition">
-            <div class="form-card__header">
-              <div class="emoji emoji--big emoji--pill with-padding-small"></div>
-            </div>
-            <div class="form-card__content">
-              <h3>Does this person have any <b>medical expenses</b>?</h3>
-              <p class="with-padding-large">E.g., medical, dental, nursing care, hospitalization, medicine, health equipment, and medical transportation.</p>
-              <div class="toolbar toolbar--centered">
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--checkmark"></span>Yes</a>
-                <a href="#" class="button toolbar__item"><span class="button__icon--left emoji emoji--inline emoji--crossmark"></span>No</a>
-              </div>
-              <ul class="progress-dots">
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-                <li class="progress-dots__dot is-completed"></li>
-              </ul>
-            </div>
-          </div>
-
-          <br><br>
-
-          <div class="form-card form-card--transition">
-            <div class="form-card__header">
-              <div class="emoji emoji--big emoji--star with-padding-med"></div>
-              <h1 class="form-card__title with-padding-med">Great, now let’s help you submit the right proof.</h1>
-            </div>
-            <div class="form-card__content">
-              <a href="#" class="button button--primary">Continue</a>
-            </div>
-          </div>
-
-          <br><br>
-
-          <div class="form-card form-card--transition">
-            <div class="form-card__content">
-              <div class="form-card__header">
-                <div class="emoji emoji--big emoji--bust with-padding-small"></div>
-                <p class="text--caps">Proof of identity</p>
-                <h3>Can you submit any of the following for Laura and Chris?</h3>
-                <ul class="with-padding-med">
-                  <li class="example">Driver's license or ID</li>
-                  <li class="example">Passport</li>
-                  <li class="example">Student, jail, or other photo ID</li>
-                </ul>
-                <div class="select">
-                  <select class="select__element" name="example_select" id="example_select">
-                    <option selected disabled>Choose a selection</option>
-                    <option value="1">I can submit now</option>
-                    <option value="2">I need more time</option>
-                    <option value="2">I need more help</option>
-                  </select>
-                </div>
-              </div>
-              <a href="#" class="button button--primary">Continue</a>
-            </div>
-          </div>
-
-          <br><br>
-
-          <div class="form-card form-card--transition">
-            <div class="form-card__content">
-              <div class="form-card__header">
-                <div class="emoji emoji--big emoji--farmer-female with-padding-small"></div>
-                <div class="emoji emoji--big emoji--construction-worker with-padding-small"></div>
-                <p class="text--caps">Proof for jobs</p>
-                <h3>Can you submit any of the following?</h3>
-                <ul class="with-padding-med">
-                  <li class="example">Pay stubs from last 30 days</li>
-                  <li class="example">Letter from employer with gross pay, hours worked, etc.</li>
-                </ul>
-                <div class="select">
-                  <select class="select__element" name="example_select" id="example_select">
-                    <option selected disabled>Choose a selection</option>
-                    <option value="1">I can submit now</option>
-                    <option value="2">I need more time</option>
-                    <option value="2">I need more help</option>
-                  </select>
-                </div>
-              </div>
-              <a href="#" class="button button--primary">Continue</a>
-            </div>
-          </div>
-        </div> <!-- .grid item -->
-      </div> <!-- .grid -->
-    </div> <!-- .slab -->
-  </div> <!-- .page-wrapper -->
-</body>
-</html>
+          <a href="#" class="button button--primary">Continue</a>
+        </div>
+      </div>
+    </div> <!-- .grid item -->
+  </div> <!-- .grid -->
+</div> <!-- .slab -->

--- a/app/views/cfa/styleguide/pages/index.html.erb
+++ b/app/views/cfa/styleguide/pages/index.html.erb
@@ -1,466 +1,403 @@
-<body class="template--styleguide">
-  <div class="page-wrapper">
-    <header class="main-header">
-      <div class="toolbar">
-        <div class="toolbar__left">
-          <h1 class="main-header__title"><a class="main-header__logo" href="#">GetCalFresh.org</a></h1>
-        </div>
-        <div class="toolbar__right">
-          <a href="#atoms" class="toolbar__item text--small link--subtle">Atoms</a>
-          <a href="#molecules" class="toolbar__item text--small link--subtle">Molecules</a>
-          <a href="#organisms" class="toolbar__item text--small link--subtle">Organisms</a>
-        </div>
-      </div>
-    </header>
-    <section class="slab slab--styleguide" id="atoms">
-      <div class="grid">
-        <div class="grid__item width-one-half shift-one-fourth">
-          <h1>Atoms</h1>
-          <p class="text--help">Atoms are the basic building blocks of matter. Applied to web interfaces, atoms are our HTML tags, such as a form label, an input or a button.</p>
-          <p class="text--help">Atoms can also include more abstract elements like color palettes, fonts and even more invisible aspects of an interface like animations.</p>
-          <p class="text--help">Like atoms in nature they’re fairly abstract and often not terribly useful on their own. However, they’re good as a reference in the context of a pattern library as you can see all your global styles laid out at a glance.</p>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Slab Layout</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-        <p>This is an example slab, it's used to section out content, especially on marketing pages. Inside of slabs, use the grid component to lay things out. Almost everything on this page is laid out using slabs and grids.</p>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Grid Layout</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/atoms/grid' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Card</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/atoms/card' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Notice</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/atoms/notice' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Colors</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/atoms/colors' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Icons</p>
-        </div>
-        <div class="grid__item width-three-fourths text--pullquote">
-          <%= styleguide_example { render partial: 'examples/atoms/icons' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Typography</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/atoms/typography' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Labels</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/atoms/labels' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Buttons</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/atoms/buttons' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Form Elements</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/atoms/form_elements' } %>
+<% content_for(:template_name) { "styleguide" } %>
 
-          <p class="text--help"><em>General atomic form elements have no knowledge about their size and default to full width. Form molecules and organisms or modifier classes should be used to define form element sizes and layout.</em></p>
-        </div>
-      </div>
-    </section>
-
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Example Pills</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/atoms/examples' } %>
-        </div>
-      </div>
-    </section>
-
-    <section class="slab slab--styleguide" id="molecules">
-      <div class="grid">
-        <div class="grid__item width-one-half shift-one-fourth">
-          <h1>Molecules</h1>
-          <p class="text--help">Things start getting more interesting and tangible when we start combining atoms together. Molecules are groups of atoms bonded together and are the smallest fundamental units of a compound. These molecules take on their own properties and serve as the backbone of our design systems.</p>
-          <p class="text--help">For example, a form label, input or button aren’t too useful by themselves, but combine them together as a form and now they can actually do something together.</p>
-          <p class="text--help">Building up to molecules from atoms encourages a “do one thing and do it well” mentality. While molecules can be complex, as a rule of thumb they are relatively simple combinations of atoms built for reuse.</p>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Media Box</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/media_box' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Toolbar</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/toolbar' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Tab bar</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/tab_bar' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Flash messages</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/flash_messages' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Progress indicator</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/progress_indicator' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Summary Table</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/summary_table' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Data Table</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/data_table' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Searchbar</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/searchbar' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Text Input Group</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/text_input_group' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Incrementer</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/incrementer' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Block Input Group</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/block_input_group' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Inline Input Group</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/inline_input_group' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Two-up Input Group</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/two_up_input_group' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Form Group</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/form_group' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Form Group Error State</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/form_group_error_state' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Follow Up Question</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/molecules/follow_up_question' } %>
-
-          <p class="text--help">How it works: the proceeding question requires an additional class "form-group--with-follow-up. Any answer that triggers a follow up should contain an additional attribute 'data-follow-up' with the value being the id of the follow-up question (starting with #).</p>
-        </div>
-      </div>
-    </section>
-
-    <section class="slab slab--styleguide" id="organisms">
-      <div class="grid">
-        <div class="grid__item width-one-half shift-one-fourth">
-          <h1>Organisms</h1>
-          <p class="text--help">Molecules give us some building blocks to work with, and we can now combine them together to form organisms. Organisms are groups of molecules joined together to form a relatively complex, distinct section of an interface.</p>
-          <p class="text--help">Organisms can consist of similar and/or different molecule types. For example, a masthead organism might consist of diverse components like a logo, primary navigation, search form, and list of social media channels. But a “product grid” organism might consist of the same molecule (possibly containing a product image, product title and price) repeated over and over again.</p>
-          <p class="text--help">Building up from molecules to organisms encourages creating standalone, portable, reusable components.</p>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Pagination</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/organisms/pagination' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Reveal</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/organisms/reveal' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Steps</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/organisms/steps' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Vertical Steps</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/organisms/vertical_steps' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Statistics Card</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/organisms/statistics_card' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Admin Application Card</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/organisms/admin_application_card' } %>
-        </div>
-      </div>
-    </section>
-    <section class="slab">
-      <div class="grid">
-        <div class="grid__item width-one-fourth">
-          <p class="text--help">Form Card</p>
-        </div>
-        <div class="grid__item width-three-fourths">
-          <%= styleguide_example { render partial: 'examples/organisms/form_card_1' } %>
-
-          <hr>
-
-          <%= styleguide_example { render partial: 'examples/organisms/form_card_2' } %>
-
-          <hr>
-
-          <%= styleguide_example { render partial: 'examples/organisms/form_card_3' } %>
-
-          <hr>
-
-          <%= styleguide_example { render partial: 'examples/organisms/form_card_4' } %>
-        </div>
-      </div>
-    </section>
-
-    <footer class="main-footer">
-      <div class="grid">
-        <div class="grid__item">
-          <div class="main-footer__legal">
-            <p>The CfA Styleguide is a pattern library developed by <a class="link--subtle" href="#">Code for America</a>.</p>
-          </div>
-        </div>
-      </div>
-    </footer>
-  </div>
-
-  <%= javascript_include_tag 'prism' %>
-
-  <script>
-  var pattern = (function() {
-
-    /**
-    <div class="pattern">
-      <div class="pattern__example">
-        PATTERN HTML GOES HERE
-      </div>
+<header class="main-header">
+  <div class="toolbar">
+    <div class="toolbar__left">
+      <h1 class="main-header__title"><a class="main-header__logo" href="#">GetCalFresh.org</a></h1>
     </div>
-    **/
+    <div class="toolbar__right">
+      <a href="#atoms" class="toolbar__item text--small link--subtle">Atoms</a>
+      <a href="#molecules" class="toolbar__item text--small link--subtle">Molecules</a>
+      <a href="#organisms" class="toolbar__item text--small link--subtle">Organisms</a>
+    </div>
+  </div>
+</header>
+<section class="slab slab--styleguide" id="atoms">
+  <div class="grid">
+    <div class="grid__item width-one-half shift-one-fourth">
+      <h1>Atoms</h1>
+      <p class="text--help">Atoms are the basic building blocks of matter. Applied to web interfaces, atoms are our HTML tags, such as a form label, an input or a button.</p>
+      <p class="text--help">Atoms can also include more abstract elements like color palettes, fonts and even more invisible aspects of an interface like animations.</p>
+      <p class="text--help">Like atoms in nature they’re fairly abstract and often not terribly useful on their own. However, they’re good as a reference in the context of a pattern library as you can see all your global styles laid out at a glance.</p>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Slab Layout</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+    <p>This is an example slab, it's used to section out content, especially on marketing pages. Inside of slabs, use the grid component to lay things out. Almost everything on this page is laid out using slabs and grids.</p>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Grid Layout</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/atoms/grid' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Card</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/atoms/card' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Notice</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/atoms/notice' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Colors</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/atoms/colors' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Icons</p>
+    </div>
+    <div class="grid__item width-three-fourths text--pullquote">
+      <%= styleguide_example { render partial: 'examples/atoms/icons' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Typography</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/atoms/typography' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Labels</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/atoms/labels' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Buttons</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/atoms/buttons' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Form Elements</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/atoms/form_elements' } %>
 
-    var p = {
+      <p class="text--help"><em>General atomic form elements have no knowledge about their size and default to full width. Form molecules and organisms or modifier classes should be used to define form element sizes and layout.</em></p>
+    </div>
+  </div>
+</section>
 
-      parseCode: function(preview) {
-        var sampleCode = $('<div>');
-        $(sampleCode).html($(preview).html())
-        $(sampleCode).find('.pattern__peripheral').remove();
-        return sampleCode;
-      },
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Example Pills</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/atoms/examples' } %>
+    </div>
+  </div>
+</section>
 
-      render: function(preview, sampleCode) {
-        var sampleCodeBox = $('<div class="pattern__code"><a href="#" class="pattern__button"><i class="icon-arrow_drop_down"></i></a><pre><code class="language-markup"></code></pre></div>');
-        $(sampleCodeBox).find('code').text($(sampleCode).html());
-        $(preview).after(sampleCodeBox);
-      },
+<section class="slab slab--styleguide" id="molecules">
+  <div class="grid">
+    <div class="grid__item width-one-half shift-one-fourth">
+      <h1>Molecules</h1>
+      <p class="text--help">Things start getting more interesting and tangible when we start combining atoms together. Molecules are groups of atoms bonded together and are the smallest fundamental units of a compound. These molecules take on their own properties and serve as the backbone of our design systems.</p>
+      <p class="text--help">For example, a form label, input or button aren’t too useful by themselves, but combine them together as a form and now they can actually do something together.</p>
+      <p class="text--help">Building up to molecules from atoms encourages a “do one thing and do it well” mentality. While molecules can be complex, as a rule of thumb they are relatively simple combinations of atoms built for reuse.</p>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Media Box</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/media_box' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Toolbar</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/toolbar' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Tab bar</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/tab_bar' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Flash messages</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/flash_messages' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Progress indicator</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/progress_indicator' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Summary Table</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/summary_table' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Data Table</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/data_table' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Searchbar</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/searchbar' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Text Input Group</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/text_input_group' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Incrementer</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/incrementer' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Block Input Group</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/block_input_group' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Inline Input Group</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/inline_input_group' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Two-up Input Group</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/two_up_input_group' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Form Group</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/form_group' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Form Group Error State</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/form_group_error_state' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Follow Up Question</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/molecules/follow_up_question' } %>
 
-      init: function() {
-        $('.pattern').each(function(index, pattern) {
-          var preview = $(this).find('.pattern__example');
-          var sampleCode = p.parseCode(preview);
-          p.render(preview, sampleCode);
+      <p class="text--help">How it works: the proceeding question requires an additional class "form-group--with-follow-up. Any answer that triggers a follow up should contain an additional attribute 'data-follow-up' with the value being the id of the follow-up question (starting with #).</p>
+    </div>
+  </div>
+</section>
 
-          $(this).find('.pattern__button').click(function(e) {
-            e.preventDefault();
-            $(this).parent().toggleClass('is-open');
-          })
+<section class="slab slab--styleguide" id="organisms">
+  <div class="grid">
+    <div class="grid__item width-one-half shift-one-fourth">
+      <h1>Organisms</h1>
+      <p class="text--help">Molecules give us some building blocks to work with, and we can now combine them together to form organisms. Organisms are groups of molecules joined together to form a relatively complex, distinct section of an interface.</p>
+      <p class="text--help">Organisms can consist of similar and/or different molecule types. For example, a masthead organism might consist of diverse components like a logo, primary navigation, search form, and list of social media channels. But a “product grid” organism might consist of the same molecule (possibly containing a product image, product title and price) repeated over and over again.</p>
+      <p class="text--help">Building up from molecules to organisms encourages creating standalone, portable, reusable components.</p>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Pagination</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/organisms/pagination' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Reveal</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/organisms/reveal' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Steps</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/organisms/steps' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Vertical Steps</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/organisms/vertical_steps' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Statistics Card</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/organisms/statistics_card' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Admin Application Card</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/organisms/admin_application_card' } %>
+    </div>
+  </div>
+</section>
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help">Form Card</p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example { render partial: 'examples/organisms/form_card_1' } %>
 
-        });
-      }
-    };
+      <hr>
 
-    return {
-      init: p.init
-    }
-  })();
+      <%= styleguide_example { render partial: 'examples/organisms/form_card_2' } %>
 
-  pattern.init();
-  </script>
-</body>
+      <hr>
+
+      <%= styleguide_example { render partial: 'examples/organisms/form_card_3' } %>
+
+      <hr>
+
+      <%= styleguide_example { render partial: 'examples/organisms/form_card_4' } %>
+    </div>
+  </div>
+</section>

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -6,13 +6,75 @@
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
 
-  <%= stylesheet_link_tag    'application', media: 'all' %>
-  <%= javascript_include_tag 'application' %>
+  <%= stylesheet_link_tag    'cfa_styleguide_main', media: 'all' %>
+  <%= stylesheet_link_tag    'prism', media: 'all' %>
+
+  <%= javascript_include_tag 'cfa_styleguide_main' %>
+  <%= javascript_include_tag 'prism' %>
 </head>
 
 <body class="template--<%= content_for(:template_name) if content_for?(:template_name) %>">
-<div class="page-wrapper">
-  <%= content_for?(:content) ? content_for(:content) : yield %>
-</div>
+  <div class="page-wrapper">
+    <%= yield %>
+  </div>
+
+  <footer class="main-footer">
+    <div class="grid">
+      <div class="grid__item">
+        <div class="main-footer__legal">
+          <p>The CfA Styleguide is a pattern library developed by <a class="link--subtle" href="#">Code for America</a>.</p>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script>
+      var pattern = (function() {
+
+          /**
+           <div class="pattern">
+           <div class="pattern__example">
+           PATTERN HTML GOES HERE
+           </div>
+           </div>
+           **/
+
+          var p = {
+
+              parseCode: function(preview) {
+                  var sampleCode = $('<div>');
+                  $(sampleCode).html($(preview).html())
+                  $(sampleCode).find('.pattern__peripheral').remove();
+                  return sampleCode;
+              },
+
+              render: function(preview, sampleCode) {
+                  var sampleCodeBox = $('<div class="pattern__code"><a href="#" class="pattern__button"><i class="icon-arrow_drop_down"></i></a><pre><code class="language-markup"></code></pre></div>');
+                  $(sampleCodeBox).find('code').text($(sampleCode).html());
+                  $(preview).after(sampleCodeBox);
+              },
+
+              init: function() {
+                  $('.pattern').each(function(index, pattern) {
+                      var preview = $(this).find('.pattern__example');
+                      var sampleCode = p.parseCode(preview);
+                      p.render(preview, sampleCode);
+
+                      $(this).find('.pattern__button').click(function(e) {
+                          e.preventDefault();
+                          $(this).parent().toggleClass('is-open');
+                      })
+
+                  });
+              }
+          };
+
+          return {
+              init: p.init
+          }
+      })();
+
+      pattern.init();
+  </script>
 </body>
 </html>

--- a/lib/cfa/styleguide/engine.rb
+++ b/lib/cfa/styleguide/engine.rb
@@ -6,7 +6,12 @@ module Cfa
       isolate_namespace Cfa::Styleguide
 
       initializer "cfa-styleguide.assets.precompile" do |app|
-        app.config.assets.precompile += %w( prism.js prism.css )
+        app.config.assets.precompile += %w(
+          cfa_styleguide_main.css
+          cfa_styleguide_main.js
+          prism.js
+          prism.css
+        )
       end
 
       config.generators do |g|

--- a/lib/cfa/styleguide/version.rb
+++ b/lib/cfa/styleguide/version.rb
@@ -1,5 +1,5 @@
 module Cfa
   module Styleguide
-    VERSION = "0.4.1"
+    VERSION = "0.4.2"
   end
 end

--- a/spec/feature/pages_spec.rb
+++ b/spec/feature/pages_spec.rb
@@ -14,4 +14,32 @@ feature 'Pages' do
     expect(page.status_code).to eq 200
     expect(page).to have_content('Atoms')
   end
+
+  scenario 'can load styleguide cbo dashboard' do
+    visit '/cfa/styleguide/cbo-dashboard'
+
+    expect(page.status_code).to eq 200
+    expect(page).to have_content('Assister dashboard')
+  end
+
+  scenario 'can load styleguide cbo analytics' do
+    visit '/cfa/styleguide/cbo-analytics'
+
+    expect(page.status_code).to eq 200
+    expect(page).to have_content('Overall numbers')
+  end
+
+  scenario 'can load styleguide current' do
+    visit '/cfa/styleguide/current'
+
+    expect(page.status_code).to eq 200
+    expect(page).to have_content('The legal stuff')
+  end
+
+  scenario 'can load styleguide custom docs' do
+    visit '/cfa/styleguide/custom-docs'
+
+    expect(page.status_code).to eq 200
+    expect(page).to have_content('First, we’ll need to figure out what proof you need to submit.')
+  end
 end


### PR DESCRIPTION
They previously defined all of their own HTML. Now we have them all
inserted into the base layout, similar to the main page.

This commit also precompiles the cfa styleguide assets, and only
includes those stylesheets and javascript + Prism on the styleguide
pages.