### PR TITLE
Remove spacing from last-child, not last-of-type

### DIFF
--- a/app/assets/stylesheets/molecules/_form-molecules.scss
+++ b/app/assets/stylesheets/molecules/_form-molecules.scss
@@ -93,7 +93,7 @@
       margin-top: -.5em;
     }
 
-    &:last-of-type {
+    &:last-child {
       margin-bottom: 0;
     }
 }


### PR DESCRIPTION
Some HTML form elements have multiple types of elements, and last-of-type does not have the intended effect (remove padding from last item in card) in these cases. This commit instead removes spacing underneath the last-child of the form card, which we (IBI) understood to be the intent (and desired spacing!).

Fixes https://github.com/codeforamerica/cfa-styleguide-gem/issues/13<Paste>