### PR TITLE
Darken base teal color to improve contrast

### DIFF
--- a/app/assets/stylesheets/atoms/_variables.scss
+++ b/app/assets/stylesheets/atoms/_variables.scss
@@ -22,7 +22,7 @@ $line-height-display: 1.3em;
 
 // Colors
 $color-background:    #FAFAF9;
-$color-teal:          #019C86;
+$color-teal:          #01846F;
 $color-magenta:       #A6005E;
 $color-tan:           #DFD7CC;
 $color-darkest-grey:  #30302F;

--- a/app/views/examples/atoms/_colors.html.erb
+++ b/app/views/examples/atoms/_colors.html.erb
@@ -1,7 +1,7 @@
 <p>
   <div class="color color--tan">#DEDED1</div>
   <div class="color color--magenta">#A6005E</div>
-  <div class="color color--teal">#019C86</div>
+  <div class="color color--teal">#01846F</div>
   <div class="color color--red">#D40000</div>
   <div class="color color--green">#009933</div>
 </p>


### PR DESCRIPTION
A fix for the issue described here: https://github.com/codeforamerica/cfa-styleguide-gem/issues/18

If I slightly darken our base teal color, the accessibility checks are happy with the contrast on all sizes of buttons (including `.button--small`). Here's what that same page on the styleguide looks like:
![screen shot 2018-11-01 at 1 49 04 pm](https://user-images.githubusercontent.com/3675092/47879304-7d083180-dddd-11e8-9aed-480ab6ba2cdf.png)

(as comparison, here's the original that's not contrasting enough now):
![screen shot 2018-11-01 at 1 51 34 pm](https://user-images.githubusercontent.com/3675092/47879908-0d934180-dddf-11e8-9911-0786036a0022.png)

There are other ways we can address the contrast (bigger font, mainly), but this felt least intrusive. What do you think, @norrishung? Look acceptable?