### PR TITLE
Add development Rails server and update development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,13 @@ Or install it yourself as:
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies. 
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+Run `bin/rails s` to start a webserver with a test app that has the engine mounted, then visit `http://localhost:3000/cfa/styleguide`. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. 
+
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ### Running tests
 

--- a/README.md
+++ b/README.md
@@ -42,15 +42,19 @@ After checking out the repo, run `bin/setup` to install dependencies.
 
 Run `bin/rails s` to start a webserver with a test app that has the engine mounted, then visit `http://localhost:3000/cfa/styleguide`. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. 
+If the gem is being used in another project's Gemfile, the source can be locally overridden within the other project's Gemfile by running `bundle config local.cfa-styleguide /path/to/cfa-styleguide-gem`, and undone with `bundle config --delete local.cfa-styleguide`
 
-To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`. 
 
 ### Running tests
 
 A small test suite is available—please add to it!
 
 To run, run `rake` or `rspec spec`.
+
+### Releasing new versions
+    
+To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
 ## Contributing
 

--- a/bin/rails
+++ b/bin/rails
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails gems
+# installed from the root of your application.
+
+ENGINE_ROOT = File.expand_path('..', __dir__)
+ENGINE_PATH = File.expand_path('../lib/cfa', __dir__)
+APP_PATH = File.expand_path('../spec/test_app/config/application', __dir__)
+
+# Set up gems listed in the Gemfile.
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+require 'rails/engine/commands'

--- a/spec/test_app/config/environments/development.rb
+++ b/spec/test_app/config/environments/development.rb
@@ -1,0 +1,3 @@
+Rails.application.configure do
+  config.consider_all_requests_local = true
+end


### PR DESCRIPTION
- Adds a rails executable to allow running bin/rails s directly from this gem for easier development.
- Expands the readme to explain how to use Bundler's local config overrides when developing against another Rails project. This is a good explanation: https://rossta.net/blog/how-to-specify-local-ruby-gems-in-your-gemfile.html

Connects to #34 (everything except the minimum Ruby version)