### PR TITLE
Document template component usage with eval

### DIFF
--- a/app/helpers/cfa/styleguide/pages_helper.rb
+++ b/app/helpers/cfa/styleguide/pages_helper.rb
@@ -9,6 +9,15 @@ module Cfa
         end
       end
 
+      def styleguide_example_eval(code)
+        content = styleguide_example { eval(code) }
+        content << content_tag(:pre, class: 'language-ruby') do
+          content_tag(:code, class: 'language-ruby') do
+            code
+          end
+        end
+      end
+
       def status_icon(icon, successful: false, failure: false, not_applicable: false)
         classes = ["status"]
         classes << "successful" if successful

--- a/app/views/cfa/styleguide/pages/index.html.erb
+++ b/app/views/cfa/styleguide/pages/index.html.erb
@@ -48,7 +48,9 @@
       <p class="text--help">Card</p>
     </div>
     <div class="grid__item width-three-fourths">
-      <%= styleguide_example { render partial: 'examples/atoms/card' } %>
+      <%= styleguide_example_eval "
+        render partial: 'examples/atoms/card'
+      " %>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Following the path of #36, there should be documentation of the higher level (above html/css) template partial/component usage. This is an example of how it might be done by documenting usage in a string, that is then eval'ed to produce the HTML for the styleguide.

<img width="1019" alt="screen shot 2018-12-20 at 8 19 47 am" src="https://user-images.githubusercontent.com/47554/50297104-d6313080-0430-11e9-882e-51476602bcdf.png">

Benefits of general approach
- doesn't require separate usage documentation that might become out-of-sync with the implementation

Drawbacks of this specific implementation
- `eval` makes me feed bad and seems insecure
- More complex examples that involve ERB `capture` blocks probably won't work

Future exploration
- having a separate directory of `<component>_example.html.erb` partials that could either be rendered (for HTML output) or `File.open.to_s` for the documentation.