### PR TITLE
Use example component partial as code example and screenshotable component

### DIFF
--- a/app/controllers/cfa/styleguide/examples_controller.rb
+++ b/app/controllers/cfa/styleguide/examples_controller.rb
@@ -1,0 +1,11 @@
+module Cfa
+  module Styleguide
+    class ExamplesController < ApplicationController
+      layout false
+
+      def show
+        @partial_path = "examples/#{params[:example_path]}"
+      end
+    end
+  end
+end

--- a/app/helpers/cfa/styleguide/pages_helper.rb
+++ b/app/helpers/cfa/styleguide/pages_helper.rb
@@ -9,12 +9,17 @@ module Cfa
         end
       end
 
-      def styleguide_example_with_code(code)
-        content = styleguide_example { ERB.new("<%= #{code} %>").result(binding).html_safe }
+      def styleguide_example_with_code(partial_path)
+        partial = lookup_context.find_template(partial_path, [], true)
+
+        filepath = partial.inspect
+        partial_contents = File.open(filepath, 'r') { |file| file.read }
+
+        content = styleguide_example { partial.render(self, {}) }
         content << content_tag(:div, class: 'pattern__code') do
           content_tag(:pre, class: 'language-ruby language-markup') do
             content_tag(:code, class: 'language-ruby') do
-              code
+              partial_contents
             end
           end
         end

--- a/app/views/cfa/styleguide/examples/show.html.erb
+++ b/app/views/cfa/styleguide/examples/show.html.erb
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <%= stylesheet_link_tag 'cfa_styleguide_main', media: 'all' %>
+  <%= javascript_include_tag 'cfa_styleguide_main' %>
+</head>
+<body>
+  <%= render @partial_path %>
+</body>

--- a/app/views/cfa/styleguide/pages/_section.html.erb
+++ b/app/views/cfa/styleguide/pages/_section.html.erb
@@ -1,0 +1,13 @@
+<% title = local_assigns.fetch(:title) %>
+<% example = local_assigns.fetch(:example) %>
+
+<section class="slab">
+  <div class="grid">
+    <div class="grid__item width-one-fourth">
+      <p class="text--help"><%= title %></p>
+    </div>
+    <div class="grid__item width-three-fourths">
+      <%= styleguide_example_with_code("examples/#{example}") %>
+    </div>
+  </div>
+</section>

--- a/app/views/cfa/styleguide/pages/index.html.erb
+++ b/app/views/cfa/styleguide/pages/index.html.erb
@@ -186,26 +186,8 @@
     </div>
   </div>
 </section>
-<section class="slab">
-  <div class="grid">
-    <div class="grid__item width-one-fourth">
-      <p class="text--help">Progress indicator</p>
-    </div>
-    <div class="grid__item width-three-fourths">
-      <%= styleguide_example { render partial: 'examples/molecules/progress_indicator' } %>
-    </div>
-  </div>
-</section>
-<section class="slab">
-  <div class="grid">
-    <div class="grid__item width-one-fourth">
-      <p class="text--help">Progress step bar</p>
-    </div>
-    <div class="grid__item width-three-fourths">
-      <%= styleguide_example_with_code("render partial: 'components/molecules/progress_step_bar', locals: { current_step: 3, step_count: 5 }") %>
-    </div>
-  </div>
-</section>
+<%= render 'section', title: 'Progress indicator', example: 'molecules/progress_indicator' %>
+<%= render 'section', title: 'Progress step bar', example: 'molecules/progress_step_bar' %>
 <section class="slab">
   <div class="grid">
     <div class="grid__item width-one-fourth">

--- a/app/views/examples/molecules/_progress_step_bar.html.erb
+++ b/app/views/examples/molecules/_progress_step_bar.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'components/molecules/progress_step_bar', locals: { current_step: 3, step_count: 5 } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Cfa::Styleguide::Engine.routes.draw do
   get '/styleguide/cbo-analytics' => 'pages#cbo_analytics', as: :styleguide_cbo_analytics
   get '/styleguide/current' => 'pages#current', as: :styleguide_current
   get '/styleguide/custom-docs' => 'pages#custom_docs', as: :styleguide_custom_docs
+  get '/styleguide/examples/*example_path' => 'examples#show', as: :styleguide_example
 end

--- a/spec/feature/examples_spec.rb
+++ b/spec/feature/examples_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+feature 'Examples' do
+  scenario 'can render out a specific example' do
+    visit '/cfa/styleguide/examples/molecules/progress_step_bar'
+
+    expect(page.status_code).to eq 200
+  end
+end


### PR DESCRIPTION
- Renders out the file contents of the component's example partial (living under `views/cfa/styleguide/examples`) for the styleguide's code example. This makes the documentation closer to how component would be used in ERB, and allows more complex (e.g. multiline or components that use `yield` or `capture`) examples. <img width="1011" alt="screen shot 2018-12-21 at 8 25 29 am" src="https://user-images.githubusercontent.com/47554/50352426-009af080-04fa-11e9-84d0-c5d428ab6592.png">

- Creates a URL path for each component example. This could be used as a target for Happo as described in #4. Example: `http://localhost:3000/cfa/styleguide/examples/molecules/progress_step_bar` 
<img width="1165" alt="screen shot 2018-12-21 at 8 26 15 am" src="https://user-images.githubusercontent.com/47554/50352476-232d0980-04fa-11e9-9865-61c659ef16d5.png">

- I extracted out the styleguide section into a separate partial too. I still see some complexity/potential-confusion in differentiating when a full partial path is being passed as an argument versus a component "identifier" that is then expanded into a full partial path.
