### PR TITLE
Update styleguide error message

### DIFF
--- a/app/models/cfa/styleguide/form_example.rb
+++ b/app/models/cfa/styleguide/form_example.rb
@@ -17,7 +17,7 @@ module Cfa
                     :example_method_with_validation_year,
                     :none
 
-      validates_presence_of :example_method_with_validation
+      validates_presence_of :example_method_with_validation, message: "This is an example error message."
     end
   end
 end


### PR DESCRIPTION
Replaces Rails' auto-generated messages with one that shows something more like we want our application to show (capitalization, punctuation).

Closes https://github.com/codeforamerica/cfa-styleguide-gem/issues/62

Here's an example:
<img width="660" alt="screen shot 2019-01-17 at 5 34 35 pm" src="https://user-images.githubusercontent.com/3675092/51359925-8c168b80-1a7e-11e9-8d43-3178dd8b6ba4.png">

