### PR TITLE
Remove stepper arrows for number input on Firefox

### DIFF
--- a/app/assets/stylesheets/molecules/_incrementer.scss
+++ b/app/assets/stylesheets/molecules/_incrementer.scss
@@ -3,6 +3,7 @@
   border-collapse: separate;
   border-spacing: 1em;
   margin-bottom: .5em;
+
   .text-input {
     appearance: none;
     display: table-cell;
@@ -15,6 +16,10 @@
     &::-webkit-inner-spin-button {
       display: none;
     }
+  }
+
+  input[type=number] {
+    -moz-appearance: textfield; // Remove stepper arrows in Firefox
   }
 }
 


### PR DESCRIPTION
Before
<img width="622" alt="Screen Shot 2019-04-03 at 4 45 26 PM" src="https://user-images.githubusercontent.com/3675092/55520182-f8416e00-562f-11e9-8fb7-9bdcffee321c.png">

After
<img width="592" alt="Screen Shot 2019-04-03 at 4 45 21 PM" src="https://user-images.githubusercontent.com/3675092/55520185-faa3c800-562f-11e9-8f3e-9dc84c15e6f4.png">

Closes https://github.com/codeforamerica/cfa-styleguide-gem/issues/94