### PR TITLE
Add support for optional progress step bar labels

### DIFF
--- a/app/assets/stylesheets/molecules/_progress-step-bar.scss
+++ b/app/assets/stylesheets/molecules/_progress-step-bar.scss
@@ -1,9 +1,13 @@
 .progress-step-bar {
+  margin: 1.5em auto 3em auto;
+  max-width: 300px;
+}
+
+.progress-step-bar__bar {
   position: relative;
   text-align: justify;
   height: 35px;
-  max-width: 300px;
-  margin: 1.5em auto 3em auto;
+
   &:before {
     content: '';
     display: block;
@@ -47,4 +51,9 @@
   @include retina-bg(icon_star_black, 20px auto);
   background-position: center center;
   background-repeat: no-repeat;
+}
+
+.progress-step-bar__label {
+  margin-top: $padding-small;
+  text-align: center;
 }

--- a/app/views/components/molecules/_progress_step_bar.html.erb
+++ b/app/views/components/molecules/_progress_step_bar.html.erb
@@ -1,11 +1,22 @@
+<% step_name = local_assigns[:step_name] || 'Step' %>
+<% step_description = local_assigns[:step_description] %>
+
+<% label_id = "progress-step-bar--#{step_name}-#{current_step + 1}-#{step_count}-label".downcase %>
+
 <div class="progress-step-bar">
-  <% (1..step_count).each do |step_number| %>
-    <% if step_number < current_step %>
-      <div class="progress-step-bar__step progress-step-bar__step--completed"></div>
-    <% elsif step_number == current_step %>
-      <div class="progress-step-bar__step progress-step-bar__step--current"></div>
-    <% else %>
-      <div class="progress-step-bar__step"></div>
+  <div class="progress-step-bar__bar" aria-labelledby="<%= label_id %>">
+    <% (1..step_count).each do |step_number| %>
+      <% if step_number < current_step %>
+        <div class="progress-step-bar__step progress-step-bar__step--completed"></div>
+      <% elsif step_number == current_step %>
+        <div class="progress-step-bar__step progress-step-bar__step--current"></div>
+      <% else %>
+        <div class="progress-step-bar__step"></div>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
+
+  <div class="progress-step-bar__label <%= 'sr-only' if step_description.blank? %>" id="<%= label_id %>">
+    <%= "#{step_name} #{current_step + 1} of #{step_count}: #{step_description}" %>
+  </div>
 </div>

--- a/app/views/examples/molecules/_progress_step_bar.html.erb
+++ b/app/views/examples/molecules/_progress_step_bar.html.erb
@@ -1,1 +1,15 @@
+<!--
+  A progress bar without a text label
+
+  Required: `current_step`, `step_count` as integers
+-->
 <%= render partial: 'components/molecules/progress_step_bar', locals: { current_step: 3, step_count: 5 } %>
+
+
+<!--
+  A progress bar with a text label
+
+  Required: `current_step`, `step_count` as integers; `step_description` (used to generate text label)
+  Optional: `step_name`
+-->
+<%= render partial: 'components/molecules/progress_step_bar', locals: { current_step: 3, step_count: 5, step_name: 'Section', step_description: 'Basic Info' } %>


### PR DESCRIPTION
Finishes https://github.com/codeforamerica/cfa-styleguide-gem/issues/105

Usages:

```
    <!-- With default step name ("Step") -->
    <%= render partial: 'components/molecules/progress_step_bar', locals: { current_step: 3, step_count: 5, step_description: 'Basic Info' } %>

    <!-- With custom step name ("Section") -->
    <%= render partial: 'components/molecules/progress_step_bar', locals: { current_step: 3, step_count: 5, step_name: 'Section', step_description: 'Basic Info' } %>

```

<img width="467" alt="Screen Shot 2019-06-17 at 5 19 08 PM" src="https://user-images.githubusercontent.com/3675092/59644930-0a598580-9124-11e9-822e-b04927bb5324.png">
