### PR TITLE
Fix bug on step progress bar: increment current_step on a 0 index system

### DIFF
--- a/app/views/components/molecules/_progress_step_bar.html.erb
+++ b/app/views/components/molecules/_progress_step_bar.html.erb
@@ -1,7 +1,7 @@
 <% step_name = local_assigns[:step_name] || 'Step' %>
 <% step_description = local_assigns[:step_description] %>
 
-<% label_id = "progress-step-bar--#{step_name}-#{current_step + 1}-#{step_count}-label".downcase %>
+<% label_id = "progress-step-bar--#{step_name}-#{current_step}-#{step_count}-label".downcase %>
 
 <div class="progress-step-bar">
   <div class="progress-step-bar__bar" aria-labelledby="<%= label_id %>">
@@ -17,6 +17,6 @@
   </div>
 
   <div class="progress-step-bar__label <%= 'sr-only' if step_description.blank? %>" id="<%= label_id %>">
-    <%= "#{step_name} #{current_step + 1} of #{step_count}: #{step_description}" %>
+    <%= "#{step_name} #{current_step} of #{step_count}: #{step_description}" %>
   </div>
 </div>

--- a/app/views/components/molecules/_progress_step_bar.html.erb
+++ b/app/views/components/molecules/_progress_step_bar.html.erb
@@ -1,7 +1,8 @@
 <% step_name = local_assigns[:step_name] || 'Step' %>
+<% step_preposition = local_assigns[:step_preposition] || 'of' %>
 <% step_description = local_assigns[:step_description] %>
 
-<% label_id = "progress-step-bar--#{step_name}-#{current_step}-#{step_count}-label".downcase %>
+<% label_id = "progress-step-bar--#{step_name}-#{step_preposition}-#{current_step}-#{step_count}-label".downcase %>
 
 <div class="progress-step-bar">
   <div class="progress-step-bar__bar" aria-labelledby="<%= label_id %>">
@@ -17,6 +18,6 @@
   </div>
 
   <div class="progress-step-bar__label <%= 'sr-only' if step_description.blank? %>" id="<%= label_id %>">
-    <%= "#{step_name} #{current_step} of #{step_count}: #{step_description}" %>
+    <%= "#{step_name} #{current_step} #{step_preposition} #{step_count}: #{step_description}" %>
   </div>
 </div>

--- a/app/views/examples/molecules/_progress_step_bar.html.erb
+++ b/app/views/examples/molecules/_progress_step_bar.html.erb
@@ -10,6 +10,6 @@
   A progress bar with a text label
 
   Required: `current_step`, `step_count` as integers; `step_description` (used to generate text label)
-  Optional: `step_name`
+  Optional: `step_name`, `step_preposition`
 -->
-<%= render partial: 'components/molecules/progress_step_bar', locals: { current_step: 3, step_count: 5, step_name: 'Section', step_description: 'Basic Info' } %>
+<%= render partial: 'components/molecules/progress_step_bar', locals: { current_step: 3, step_count: 5, step_name: 'Section', step_description: 'Basic Info', step_preposition: 'of' } %>


### PR DESCRIPTION
![Screen Shot 2019-06-26 at 12 57 36 PM](https://user-images.githubusercontent.com/49880002/60210569-04456200-9812-11e9-9023-80bbe3557814.png)

@hartsick unsure if we are trying to preface the sections, but it runs into an awkward problem at the end of the steps where the current step is greater than the total number of steps