### PR TITLE
Fix follow-up to work for single checkbox

### DIFF
--- a/app/assets/javascripts/cfa_styleguide_main.js
+++ b/app/assets/javascripts/cfa_styleguide_main.js
@@ -126,7 +126,9 @@ var followUpQuestion = (function() {
           $(self).find('.question-with-follow-up__follow-up').hide();
 
           // show the current follow up
-          $($(this).attr('data-follow-up')).show();
+          if($(this).is(':checked') && $(this).attr('data-follow-up') != null) {
+            $($(this).attr('data-follow-up')).show();
+          }
         })
       });
     }

--- a/app/views/examples/molecules/_follow_up_question.html.erb
+++ b/app/views/examples/molecules/_follow_up_question.html.erb
@@ -1,4 +1,5 @@
 <form action="POST">
+  <!-- Follow-up with a radio button -->
   <div class="question-with-follow-up">
     <div class="question-with-follow-up__question">
       <fieldset class="form-group">
@@ -39,6 +40,26 @@
           </label>
         </radiogroup>
       </fieldset>
+    </div>
+  </div>
+
+  <!-- Follow-up with a checkbox -->
+  <div class="question-with-follow-up">
+    <div class="question-with-follow-up__question">
+      <fieldset class="form-group">
+        <label class="checkbox">
+          <input data-follow-up="#different-preferred-name-follow-up" type="checkbox" value="1" name="example_name_checkbox" id="example_name_checkbox">
+          I prefer a different first name
+        </label>
+      </fieldset>
+    </div>
+    <div class="question-with-follow-up__follow-up" id="different-preferred-name-follow-up">
+      <div class="form-group">
+        <label for="member_preferred_first_name">
+          <p class="form-question">What is your preferred first name?</p>
+        </label>
+        <input type="text" class="text-input" name="example_name_preferred" id="example_name_preferred">
+      </div>
     </div>
   </div>
 </form>


### PR DESCRIPTION
It looks like the follow-up question component _was_ intended to work
with checkboxes (since it clears the checked state proactively), but in
practice it didn't: When unchecking the checkbox, the call to $.show()
would trigger, resulting in the follow-up never disappearing.

By copying the conditional logic used during initialization here, we can
make it work for a single checkbox.

I've added an example to the styleguide page to assist future
implementers.