### PR TITLE
Hide unchecked follow up questions on page load

### DIFF
--- a/app/assets/javascripts/cfa_styleguide_main.js
+++ b/app/assets/javascripts/cfa_styleguide_main.js
@@ -111,10 +111,10 @@ var followUpQuestion = (function() {
       $('.question-with-follow-up').each(function(index, question) {
         var self = this;
 
-        // if any initial questions are already selected on page load, show the follow up
+        // set initial state of follow-ups based on the page
         $(this).find('input').each(function(index, input) {
-          if($(this).is(':checked') && $(this).attr('data-follow-up') != null) {
-            $($(this).attr('data-follow-up')).show();
+          if($(this).attr('data-follow-up') != null) {
+            $($(this).attr('data-follow-up')).toggle($(this).is(':checked'));
           }
         });
 


### PR DESCRIPTION
We want to do a progressive enhancement follow up question in GCF, where
the follow up is shown by default and hidden with JS. It looks like the
inverse of the necessary logic already existed -- to expand follow-up
questions that were checked -- so this commit updates the logic to also
hide follow-up questions that are unchecked.

(Note: Consumers of the component will have to set "display:
block" on the component themselves to get the progressive enhancement
behavior.)