### PR TITLE
Adding an accordion pattern

### DIFF
--- a/app/assets/images/icon_accordion_close.svg
+++ b/app/assets/images/icon_accordion_close.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="15px" height="4px" viewBox="0 0 15 4" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
+    <title>+</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Accordion-Open" transform="translate(-293.000000, -38.000000)" fill="#121111" fill-rule="nonzero">
+            <polygon id="+" points="298.216049 41.6419753 293 41.6419753 293 38 298.216049 38 302.166667 38 307.382716 38 307.382716 41.6419753 302.166667 41.6419753"></polygon>
+        </g>
+    </g>
+</svg>

--- a/app/assets/images/icon_accordion_open.svg
+++ b/app/assets/images/icon_accordion_open.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="15px" height="15px" viewBox="0 0 15 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 58 (84663) - https://sketch.com -->
+    <title>+</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Accordion" transform="translate(-293.000000, -33.000000)" fill="#121111" fill-rule="nonzero">
+            <polygon id="+" points="302.166667 48 298.216049 48 298.216049 42.3209877 293 42.3209877 293 38.6790123 298.216049 38.6790123 298.216049 33 302.166667 33 302.166667 38.6790123 307.382716 38.6790123 307.382716 42.3209877 302.166667 42.3209877"></polygon>
+        </g>
+    </g>
+</svg>

--- a/app/assets/javascripts/cfa_styleguide_main.js
+++ b/app/assets/javascripts/cfa_styleguide_main.js
@@ -236,6 +236,30 @@ var showMore = (function () {
   }
 })();
 
+var accordion = (function() {
+  var ac = {
+    init: function() {
+      $('.accordion').each(function(index, accordion) {
+        var self = accordion;
+        $(self).addClass('accordion--is-closed');
+        $(self).find('.accordion__button').attr('aria-expanded', "false");
+        $(self).find('.accordion__button').click(function(e) {
+          e.preventDefault();
+          $(self).toggleClass('accordion--is-closed');
+          if($(self).find('.accordion__button').attr('aria-expanded') == "false") {
+            $(self).find('.accordion__button').attr('aria-expanded', "true");
+          }
+          else {
+            $(self).find('.accordion__button').attr('aria-expanded', "false");
+          }
+        });
+      });
+    }
+  }
+  return {
+    init: ac.init
+  }
+})();
 
 $(document).ready(function() {
   radioSelector.init();
@@ -246,4 +270,5 @@ $(document).ready(function() {
   inputGroupSelector.init();
   noneOfTheAbove.init();
   showMore.init();
+  accordion.init();
 });

--- a/app/assets/stylesheets/cfa_styleguide_main.scss
+++ b/app/assets/stylesheets/cfa_styleguide_main.scss
@@ -35,6 +35,7 @@
 @import 'molecules/progress-indicator';
 @import 'molecules/progress-step-bar';
 @import 'molecules/reveal';
+@import 'molecules/accordion';
 @import 'molecules/scroller';
 @import 'molecules/searchbar';
 @import 'molecules/steps';

--- a/app/assets/stylesheets/molecules/_accordion.scss
+++ b/app/assets/stylesheets/molecules/_accordion.scss
@@ -3,6 +3,7 @@
 	border: 2px solid $color-grey;
 	border-radius: 10px; // Replace with $border-radius-large when styleguide is updated
 	padding: 15px; // Replace with $s15 when styleguide is updated
+	margin-bottom: 15px; // Replace with $s15 when styleguide is updated
 }
 
 .accordion__button {

--- a/app/assets/stylesheets/molecules/_accordion.scss
+++ b/app/assets/stylesheets/molecules/_accordion.scss
@@ -13,6 +13,7 @@
 	text-align: left;
 	font-weight: bold;
 	text-decoration: none;
+	padding-right: 35px; // Replace with $s35 when styleguide is updated
 	&:after {
 		content: '';
 		display: block;
@@ -35,7 +36,7 @@
 }
 
 .accordion__content {
-	margin-top: 35px; // Replace with $s15 when styleguide is updated
+	margin-top: 35px; // Replace with $s35 when styleguide is updated
 	display: block;
 
 	.accordion--is-closed & {

--- a/app/assets/stylesheets/molecules/_accordion.scss
+++ b/app/assets/stylesheets/molecules/_accordion.scss
@@ -1,0 +1,44 @@
+.accordion {
+	background-color: $color-grey-light;
+	border: 2px solid $color-grey;
+	border-radius: 10px; // Replace with $border-radius-large when styleguide is updated
+	padding: 15px; // Replace with $s15 when styleguide is updated
+}
+
+.accordion__button {
+	@extend .button--link;
+	position: relative;
+	display: block;
+	width: 100%;
+	text-align: left;
+	font-weight: bold;
+	text-decoration: none;
+	&:after {
+		content: '';
+		display: block;
+		position: absolute;
+		right: 0;
+		top: 50%;
+		margin-top: -7px; // Replace with $s15/2 when styleguide is updated
+		width: 15px; // Replace with $s15 when styleguide is updated
+		height: 15px; // Replace with $s15 when styleguide is updated
+		background-image: image-url('icon_accordion_close.svg');
+		background-repeat: no-repeat;
+		background-position: center center;
+	}
+
+	.accordion--is-closed & {
+		&:after {
+			background-image: image-url('icon_accordion_open.svg');
+		}
+	}
+}
+
+.accordion__content {
+	margin-top: 35px; // Replace with $s15 when styleguide is updated
+	display: block;
+
+	.accordion--is-closed & {
+		display: none;
+	}
+}

--- a/app/views/cfa/styleguide/pages/index.html.erb
+++ b/app/views/cfa/styleguide/pages/index.html.erb
@@ -59,6 +59,7 @@
 <%= render 'section', title: 'Progress indicator', example: 'molecules/progress_indicator' %>
 <%= render 'section', title: 'Progress step bar', example: 'molecules/progress_step_bar' %>
 <%= render 'section', title: 'Reveal', example: 'molecules/reveal' %>
+<%= render 'section', title: 'Accordion', example: 'molecules/accordion' %>
 <%= render 'section', title: 'Show More', example: 'molecules/show_more' %>
 <%= render 'section', title: 'Summary Table', example: 'molecules/summary_table' %>
 <%= render 'section', title: 'Data Table', example: 'molecules/data_table' %>

--- a/app/views/examples/molecules/_accordion.html.erb
+++ b/app/views/examples/molecules/_accordion.html.erb
@@ -1,6 +1,12 @@
 <div class="accordion">
-	<button href="#" class="accordion__button" aria-expanded="true" aria-controls="a1">What documents will I need to provide to get CalFresh?</button>
+	<button href="#" class="accordion__button" aria-expanded="true" aria-controls="a1">What is an accordion used for?</button>
 	<div class="accordion__content" id="a1">
+		<p>An accordion element allows the user to expand and hide content on a page. Multiple accordions are usually used in tandem. It is useful to break up long pages for easy scannability.</p>
+	</div>
+</div>
+<div class="accordion">
+	<button href="#" class="accordion__button" aria-expanded="true" aria-controls="a2">What documents will I need to provide to get CalFresh?</button>
+	<div class="accordion__content" id="a2">
 		<p><b>These documents are usually required to get CalFresh:</b></p>
 		<ul class="list--bulleted">
 			<li>A copy of your ID</li>

--- a/app/views/examples/molecules/_accordion.html.erb
+++ b/app/views/examples/molecules/_accordion.html.erb
@@ -1,0 +1,31 @@
+<div class="accordion">
+	<button href="#" class="accordion__button" aria-expanded="true" aria-controls="a1">What documents will I need to provide to get CalFresh?</button>
+	<div class="accordion__content" id="a1">
+		<p><b>These documents are usually required to get CalFresh:</b></p>
+		<ul class="list--bulleted">
+			<li>A copy of your ID</li>
+			<li>Proof of any income from the last 30 days</li>
+			<li>Proof of student status (for college students)</li>
+		</ul>
+
+		<p><b>Immigrants may also be asked to provide proof of status to get benefits:</b></p>
+		<ul class="list--bulleted">
+			<li>Copy of your green card (both sides)</li>
+			<li>A copy of your most recent paperwork for a U Visa, T Visa, Asylum, Refugee or Parolee status, or VAWA petition</li>
+			<li>Naturalized US Citizens may be asked to provide a copy of their US passport or naturalization papers</li>
+			<li>Important: If you are only applying for other people in your household, you don’t have to provide proof of immigration status. </li>
+		</ul>
+		
+
+		<p><b>These documents are optional but can increase your benefit amount:</b></p>
+		<ul class="list--bulleted">
+			<li>Proof of housing expenses</li>
+			<li>Proof of child support paid</li>
+			<li>Proof of child/dependent care paid</li>
+			<li>If you are 60+ or disabled, proof of medical expenses</li>
+		</ul>
+		
+		<p><b>What if I can’t get the proof?</b></p>
+		<p>Tell your case worker during your CalFresh applicant interview. CalFresh will generally accept a sworn statement as a last resort if you cannot get the documents needed.</p>
+	</div>
+</div>


### PR DESCRIPTION
This PR adds an accordion pattern to our styleguide:

- Includes accordion css
- Includes accordion javascript
- Includes an accordion html example
- Adds the accordion example and description to the styleguide index page

Testing:

- Accordion has been tested for responsive design (Mobile Safari and Desktop Safari)
- Accordion has been tested for cross-browser compatibility (Chrome, Safari, Firefox)
- Accordion has been tested in Desktop Safari with Javascript disabled.
- Accordion has been tested with VoiceOver on iOS on an iPhone X

Notes on graceful degradation, accessibility, and css:

1. This accordion is open (and therefore visible) by default if there is no javascript enabled. If javascript is enabled, it closes the accordion on document ready and adds an "click" event listening to open it.

2. I have included `aria-expanded` and `aria-controls` on the `<button>` element. This matches the recommendation by [W3C](https://www.w3.org/TR/wai-aria-practices/examples/accordion/accordion.html) and implementation by [USWDS](https://designsystem.digital.gov/components/accordion/). There are a few other recommendations based on the W3C guidelines but I wasn't sure how important they were. Happy to review this with an accessibility-knowledgable engineer.

3. There are some spacing variables that would have been helpful that I created in a separate PR. I didn't want to gate this pattern on merging that PR so I just left comments on where those values should be replaced by those variables.

Here is a video of the accordion in action:

[accordion.zip](https://github.com/codeforamerica/cfa-styleguide-gem/files/3699973/accordion.zip)