### PR TITLE
Add crossmark and checkmark list patterns to design system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 yarn-debug.log*
 .yarn-integrity
 .git-authors
+.DS_Store

--- a/app/assets/stylesheets/atoms/_typography.scss
+++ b/app/assets/stylesheets/atoms/_typography.scss
@@ -178,23 +178,30 @@ ol, ul {
   }
 }
 
-.list--checkmark {
+.list--checkmark, .list--crossmark {
   li {
     position: relative;
-    padding-left: 4em;
-    margin-bottom: 4em;
+    margin-left: 25px;
+    padding-left: 25px;
+    margin-bottom: 15px;
     &:before {
       content: '';
       display: block;
       position: absolute;
       left: 0;
       top: .25em;
-      width: 2em;
-      height: 2em;
+      width: 25px;
+      height: 15px;
+      background-image: image-url('emojis/checkmark.png');
       background-repeat: no-repeat;
-      @include retina-bg(illustration_success, 2em auto);
-      background-size: 2em auto;
+      background-size: auto 15px;
     }
+  }
+}
+
+.list--crossmark {
+  li:before {
+    background-image: image-url('emojis/crossmark.png');
   }
 }
 

--- a/app/views/examples/atoms/_typography.html.erb
+++ b/app/views/examples/atoms/_typography.html.erb
@@ -30,3 +30,15 @@
   <li>Numbered list item 2</li>
   <li>Numbered list item 3</li>
 </ol>
+
+<ul class="list--checkmark">
+  <li>Checkmark list item 1</li>
+  <li>Checkmark list item 2</li>
+  <li>Checkmark list item 3</li>
+</ul>
+
+<ul class="list--crossmark">
+  <li>Crossmark list item 1</li>
+  <li>Crossmark list item 2</li>
+  <li>Crossmark list item 3</li>
+</ul>


### PR DESCRIPTION
This pull request adds `list--checkmark` and `list--crossmark` patterns to the honeycrisp design system. They are necessary for the immigration guide page on GCF but we think they will be useful across other projects as well.

This has been checked for cross-browser compatiability (Safari, Firefox, Chrome, and Mobile Safari). It has also been checked for responsive design.

<img width="262" alt="Screen Shot 2019-10-09 at 3 08 53 PM" src="https://user-images.githubusercontent.com/606439/66512559-38821d00-eaa7-11e9-8e63-30a9a2a0fa24.png">
<img width="276" alt="Screen Shot 2019-10-09 at 3 08 56 PM" src="https://user-images.githubusercontent.com/606439/66512560-38821d00-eaa7-11e9-8fb0-073d9ad17cf8.png">

