### PR TITLE
Use prism.js from cdnjs instead of a gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,6 @@ PATH
       bourbon
       jquery-rails
       neat (~> 1.8.0)
-      prism-rails
 
 GEM
   remote: https://rubygems.org/
@@ -144,8 +143,6 @@ GEM
       ast (~> 2.4.0)
     percy-capybara (4.0.0.pre.beta2)
     powerpack (0.1.2)
-    prism-rails (1.6.0.3)
-      railties (>= 4.2, < 6)
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)

--- a/app/helpers/cfa/styleguide/pages_helper.rb
+++ b/app/helpers/cfa/styleguide/pages_helper.rb
@@ -17,8 +17,8 @@ module Cfa
 
         content = styleguide_example { partial.render(self, {}) }
         content << content_tag(:div, class: "pattern__code") do
-          content_tag(:pre, class: "language-ruby language-markup") do
-            content_tag(:code, class: "language-ruby") do
+          content_tag(:pre) do
+            content_tag(:code, class: "language-erb") do
               partial_contents
             end
           end

--- a/app/views/examples/atoms/_labels.html.erb
+++ b/app/views/examples/atoms/_labels.html.erb
@@ -5,4 +5,4 @@
   <%= render 'components/atoms/label', text: 'Green', variant: 'done' %>
   <%= render 'components/atoms/label', text: 'In Progress', variant: 'orange' %>
   <%= render 'components/atoms/label', text: 'Error', variant: 'red' %>
-</p
+</p>

--- a/app/views/layouts/main.html.erb
+++ b/app/views/layouts/main.html.erb
@@ -7,10 +7,11 @@
   <%= csp_meta_tag %>
 
   <%= stylesheet_link_tag    'application', media: 'all' %>
-  <%= stylesheet_link_tag    'prism', media: 'all' %>
+  <%= stylesheet_link_tag    'https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/themes/prism.min.css', media: 'all' %>
 
   <%= javascript_include_tag 'application' %>
-  <%= javascript_include_tag 'prism' %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/components/prism-core.min.js' %>
+  <%= javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/prism/1.17.1/plugins/autoloader/prism-autoloader.min.js' %>
 </head>
 
 <body class="template--<%= content_for(:template_name) if content_for?(:template_name) %>">

--- a/cfa-styleguide.gemspec
+++ b/cfa-styleguide.gemspec
@@ -36,7 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "bourbon"
   spec.add_runtime_dependency "jquery-rails"
   spec.add_runtime_dependency "neat", "~> 1.8.0"
-  spec.add_runtime_dependency "prism-rails"
   spec.add_development_dependency "axe-matchers", "~> 2.2"
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "capybara"

--- a/lib/cfa/styleguide/engine.rb
+++ b/lib/cfa/styleguide/engine.rb
@@ -1,16 +1,12 @@
 module Cfa
   module Styleguide
     class Engine < ::Rails::Engine
-      require "prism-rails"
-
       isolate_namespace Cfa::Styleguide
 
       initializer "cfa-styleguide.assets.precompile" do |app|
         app.config.assets.precompile += %w(
           cfa_styleguide_main.css
           cfa_styleguide_main.js
-          prism.js
-          prism.css
         )
       end
 


### PR DESCRIPTION
The prism-rails gem is sparsley updated and includes a version of prism from 2017;
prism has been updated a number of times since then.

Additionally and more importantly, it locks the rails version at "< 6", which is not
good if you're trying to upgrade to Rails 6

The downside of loading it from a CDN is that you won't be able to view the
full-fidelity styleguide when on an airplane or exploring the earth's core.

also: change block languages from 'language-ruby' to 'language-erb' to make the syntax
highlighting more correct

Fixes #106