### PR TITLE
[do not merge] Add migration guide

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,11 +1,11 @@
 # Migration Guide
 
-## Migrating from 0.7.x to 0.8.0
+## Migrating from <= 0.8.x to 0.9.0
 
 For a full diff of changes, view the [pull request](https://github.com/codeforamerica/cfa-styleguide-gem/pull/123/files). A summary of significant changes is below.
 
 ### Breaking changes: SASS variables
-In `0.8.0`, various SASS variables have been removed and will cause breakage if they're continued to be used in the host application.
+In `0.9.0`, various SASS variables have been removed and will cause breakage if they're continued to be used in the host application.
 
 Below are the variables that have been removed, along with their suggested replacements:
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,0 +1,42 @@
+# Migration Guide
+
+## Migrating from 0.7.x to 0.8.0
+
+For a full diff of changes, view the [pull request](https://github.com/codeforamerica/cfa-styleguide-gem/pull/123/files). A summary of significant changes is below.
+
+### Breaking changes: SASS variables
+In `0.8.0`, various SASS variables have been removed and will cause breakage if they're continued to be used in the host application.
+
+Below are the variables that have been removed, along with their suggested replacements:
+
+|original|suggested replacement|
+|---|---|
+|$padding-small|$s10|
+|$padding-med|$s35|
+|$padding-large|$s60|
+|$padding-huge|$s155|
+|$font-size-normal|$font-size-25|
+|$font-size-small|$font-size-25-small|
+|$font-size-smallest|$font-size-15|
+|$font-size-normal|$font-size-25|
+|$font-size-h1|$font-size-60|
+|$font-size-h2|$font-size-35|
+|$font-size-h3|$font-size-25|
+|$font-size-h4|$font-size-25-small|
+|$line-height-normal|$s25|
+|$line-height-display|$s35|
+|$color-darkest-grey|#121111|
+|$color-dark-grey|#5F5854|
+|$color-light-grey|#F7F5F4|
+|$color-tan|#DFD7CC|
+|$color-orange|#D48C00|
+|$color-text-on-orange|#3D2800|
+
+### Changes to overrides: SASS organization
+`layout.scss` has been split into `slabs.scss` and `notices.scss`.
+
+Spacing classes have been moved from `utilities.scss` to `spacing.scss`.
+
+### Removals: CSS classes
+A handful of CSS classes have been removed. If your project needs them or you're concerned 
+about breaking, review the [diff](https://github.com/codeforamerica/cfa-styleguide-gem/pull/123/files).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ We are not currently seeking contributions from the public.
 
 If you have any thoughts or questions about the project, get in touch at <a href="mailto:styleguide@codeforamerica.org">styleguide@codeforamerica.org</a> or the `#cfa-design-toolkit` channel in the Code for America Slack.
 
-
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -66,15 +65,43 @@ Or install it yourself as:
     @import 'things_to_import'
     ```
 
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You must install Chromedriver to run tests; on MacOS with Homebrew, run `brew bundle install`
 
 Run `bin/rails s` to start a webserver with a test app that has the engine mounted, then visit `http://localhost:3000`.
 
-If the gem is being used in another project's Gemfile, the source can be locally overridden within the other project's Gemfile by running `bundle config local.cfa-styleguide /path/to/cfa-styleguide-gem`, and undone with `bundle config --delete local.cfa-styleguide`
+### Overriding this gem locally in another project
 
-To install this gem onto your local machine, run `bundle exec rake install`. 
+If the gem is being used in another project's Gemfile, the source can be locally overridden within the other project's Gemfile in two ways:
+
+1. Change the bundler configuration to use the local gem repository
+
+    In the terminal, run `bundle config local.cfa-styleguide /path/to/cfa-styleguide-gem`
+
+    To install this gem onto your local machine, run `bundle exec rake install`.
+  
+    When finished with development, remove this configuration by running `bundle config --delete local.cfa-styleguide` and `bundle install`
+  
+1. Change your Gemfile to point to the local gem repository 
+
+    Alternatively, you can change host project's `Gemfile` to point to a local copy of this repository. For example, changing:
+
+    ```
+    gem 'cfa-styleguide', '~> 0.7', github: 'codeforamerica/cfa-styleguide-gem'
+    ```
+    to
+    ```
+    gem 'cfa-styleguide', '~> 0.7', path: '../cfa-styleguide-gem'
+    ```
+    
+    where `../cfa-styleguide-gem` is the path (relative or absolute) to this repo on the local filesystem.
+    
+    After updating the `Gemfile` with these changes, you will need to run `bundle install`.
+    
+    When finish, just revert the Gemfile to the original version and `bundle install` again.
+
 
 ### Running tests
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,20 @@ Or install it yourself as:
 
     $ gem install cfa-styleguide
 
+## Upgrading
+
+The styleguide gem is pre-1.0.0 release, and should be considered as being in beta.
+
+We do our best to keep things stable between minor version releases; 
+however, decisions about deprecation and breaking changes are made given our knowledge about
+the usage of the gem by active projects maintained and developed by Code for America staff.
+
+**When upgrading the gem between patch versions** (e.g. 0.7.1 to 0.7.2), expect no breakage.
+
+**When upgrading the gem between minor versions** (e.g. 0.7.1 to 0.8.0), be sure to review the [changelog](./CHANGELOG.md) and [migration guide](./MIGRATING.md).
+
+If you encounter any breaking changes that we have not documented, please let us know by opening an issue!
+
 ## Usage
 
 1. Add `@import 'cfa_styleguide_main';` to application.scss.
@@ -114,7 +128,8 @@ To run, run `rake` or `rspec spec`.
 To release a new version, on `master` branch:
 * Update the version number in `version.rb` using [semantic versioning](https://semver.org/)
 * `bundle install` to update the Gemfile.lock
-* Generate a changelog using `bundle exec rake changelog`. (Note: you will need to provide a [Github token with public repo access](https://github.com/github-changelog-generator/github-changelog-generator#github-token)). 
+* Generate an addition to the [changelog](./CHANGELOG.md) using `bundle exec rake changelog`. (Note: you will need to provide a [Github token with public repo access](https://github.com/github-changelog-generator/github-changelog-generator#github-token)).
+* If updating the minor version, update the [migration guide](./MIGRATING.md) with any breaking changes and suggestions for what to do about them. If no breaking changes, just add 'no breaking changes'. 
 * Review, edit as necessary, and commit including the version update.
 * Run `bundle exec rake release`, which will create a git tag for the version, and push git commits and tags to Github. In the future, this will also push the `.gem` file to [rubygems.org](https://rubygems.org).
 


### PR DESCRIPTION
This takes a stab at making a migration guide for use with https://github.com/codeforamerica/cfa-styleguide-gem/pull/123, with the intention of making it easier for people outside CFA to upgrade between versions. 

This PR should be merged after 123 is merged to master, before or as part of the release of 0.8.0.