### PR TITLE
Autoprefix CSS for distribution assets

### DIFF
--- a/lib/tasks/distribution.rb
+++ b/lib/tasks/distribution.rb
@@ -1,6 +1,7 @@
 require "fileutils"
 require "sassc"
 require "sprockets_extension/uglifier_source_maps_compressor"
+require "autoprefixer-rails"
 
 class Distribution
   DIST_PATH = "#{Dir.pwd}/dist".freeze
@@ -118,7 +119,7 @@ class Distribution
     options[:style] = :compressed if compressed
 
     engine = SassC::Engine.new(scss_file, options)
-    css = engine.render
+    css = AutoprefixerRails.process(engine.render).css
     add_version_comment(css)
     File.write("#{CSS_PATH}/#{css_filename}", css)
 


### PR DESCRIPTION
This closes #287.

# What does this PR do?

When running `rake assets:package`, the CSS assets aren't run through a [vendor autoprefixer](https://developer.mozilla.org/en-US/docs/Glossary/Vendor_Prefix), as [happens automatically in a Rails app with the `autoprefixer-rails` gem](https://github.com/ai/autoprefixer-rails#ruby-on-rails).

Calling [autoprefixer manually in Ruby](https://github.com/ai/autoprefixer-rails#ruby) is able to vendor prefix the CSS that gets pushed to the `/dist` folder.

## Why does this matter?

Automatically adding vendor prefixes adding better CSS support for older browsers.

In the Percy issues, Firefox `v73.0` CSS needed an old `-moz-` prefix for `appearance` so that a `<select>` element can be customized.

<img width="1883" alt="Screen Shot 2021-08-25 at 4 08 05 PM" src="https://user-images.githubusercontent.com/9101728/130864985-7a33edd3-8ff4-4310-8827-a972cbc6a421.png">

## How to test this?

After running `rake assets:package`, the outputted CSS (both `.css` and `.min.css`) should have `-moz-` `-webkit` vendor prefixes.

For example:

**Before**

<img width="783" alt="before-css" src="https://user-images.githubusercontent.com/9101728/130871929-cf9694c9-8345-48c3-a1c4-762e10579698.png">


<img width="912" alt="before-min-css" src="https://user-images.githubusercontent.com/9101728/130871920-30a25ea3-2de8-4721-a924-7a75e6bb5f17.png">


**After**

<img width="738" alt="after-css" src="https://user-images.githubusercontent.com/9101728/130871947-c769fa0d-3bb1-4161-878f-965c5ed10de6.png">

<img width="846" alt="after-min-css" src="https://user-images.githubusercontent.com/9101728/130871956-e15a1eaa-6b49-4031-b764-cbbbe4f60c89.png">

